### PR TITLE
Add simpler command to initiate LabGym

### DIFF
--- a/LabGym/__main__.py
+++ b/LabGym/__main__.py
@@ -1,0 +1,3 @@
+from . import gui
+
+gui.gui()

--- a/README.md
+++ b/README.md
@@ -158,15 +158,9 @@ Two detection methods to fit different scenarios:
 
 # Initiate user interface for each use
 
-1. Activate Python3 by typing 'python3' or 'py' in the terminal / cmd prompt. Then type:
+Type the following command to initiate LabGym.
 
-        from LabGym import gui
-
-2. Then type:
-
-        gui.gui()
-
-    Now the user interface is initiated and ready to use.
+      python3 -m LabGym
 
 <p>&nbsp;</p>
 


### PR DESCRIPTION
To launch LabGym, we currently need to enter the Python interpreter and type two commands to initiate LabGym. Adding those two commands to a file called `LabGym/__main__.py` makes it so that we can use the single command `python -m LabGym` to start the app. This change maintains backwards compatibility with the old method, since the `LabGym.gui` module still exists.

I edited the README to reflect this simpler startup command, but I wasn't able to adjust the user guide, since it's a PDF file. Perhaps we can make this change in the next released version?