### PR TITLE
Add exit condition for FPS dialog in preprocessing module

### DIFF
--- a/LabGym/gui_preprocessors.py
+++ b/LabGym/gui_preprocessors.py
@@ -556,6 +556,8 @@ class WindowLv2_ProcessVideos(wx.Frame):
                         "Error",
                         wx.OK | wx.ICON_ERROR,
                     )
+            else:
+                break
         fps_dialog.Destroy()
 
     def preprocess_videos(self, event):


### PR DESCRIPTION
When I was writing the FPS dialog, I forgot to add a condition that closes the dialog if the "Cancel" button is pressed, which caused the dialog to keep reappearing. This change fixes that bug so that the dialog disappears as intended when "Cancel" is pressed. 