### PR TITLE
Test pull request documentation builds

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,8 +8,8 @@
 ```{toctree}
 :hidden:
 
-installation/index
 what-can-labgym-do
+installation/index
 walkthroughs/index
 features/index
 issues

--- a/docs/installation/linux.md
+++ b/docs/installation/linux.md
@@ -49,6 +49,3 @@ Using the Windows Subsystem for Linux (WSL), or a Linux machine, install LabGym 
    >>> gui.gui()
    ```
    If the LabGym GUI shows up, you have successfully installed LabGym!
-
-To close LabGym, enter `Ctrl+C` while on your terminal to terminate the process.
-


### PR DESCRIPTION
I made a trivial change to the documentation to test out the "Build pull requests" setting on ReadTheDocs.io. If this works, we should be able to access the documentation for this and any future pull requests through the documentation website. This will allow us to confirm that the documentation looks correct before merging into `master`. 

Please **do not** merge the pull request until I have confirmed that the docs configuration is working.
