### PR TITLE
Update installation method

### DIFF
--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -7,6 +7,12 @@ dependencies installed and available on `PATH`:
  - Git
  - A C/C++ compiler (e.g. `gcc`, `clang`, or Microsoft Visual C++)
 
+If you are on a Windows or Linux system with an Nvidia GPU, you will need the
+following installed to enable GPU-accelerated training:
+
+ - CUDA Toolkit 11.8
+ - cuDNN
+
 We recommend that you follow the instructions below for your operating system
 to ensure that the installation goes smoothly. However, if your system
 configuration requires that you install these dependencies in a different way,
@@ -14,7 +20,7 @@ configuration requires that you install these dependencies in a different way,
 free to go ahead and do that.
 
 Regardless of your system configuration, we strongly recommend using 
-[`pipx`](https://pipx.pypa.io/stable/installation/) to install LabGym. if
+[`pipx`](https://pipx.pypa.io/stable/installation/) to install LabGym. If
 you use Python for other research tasks, you might have multiple version of
 Python installed, as well as versions of libraries like NumPy and TensorFlow
 that LabGym is incompatible with. Using `pipx` ensures that LabGym and its 

--- a/docs/installation/linux.md
+++ b/docs/installation/linux.md
@@ -87,6 +87,14 @@ If you're using Arch Linux or one of its derivatives, we assume you have the
    ```console
    $ pipx install --python python3.10 LabGym
    ```
+   
+   ```{note}
+   If you're on WSL and you run into issues with the installation of wxPython,
+   use [this resource](https://www.pixelstech.net/article/1599647177-Problem-and-Solution-for-Installing-wxPython-on-Ubuntu-20-04)
+   to install the necessary dependencies for wxPython. Then, rerun the above
+   command to install LabGym.
+   ```
+
 6. Install PyTorch in LabGym's virtual environment.
 
    ```pwsh-session

--- a/docs/installation/linux.md
+++ b/docs/installation/linux.md
@@ -1,4 +1,4 @@
-# Linux
+# Linux/WSL2
 
 Depending on which distribution of Linux you use, the process of installing
 packages will look slightly different. Select the appropriate distribution
@@ -13,7 +13,7 @@ If you're using Arch Linux or one of its derivatives, we assume you have the
 1. Update your system's package manager, then install `gcc`, `git`, and 
    Python 3.10.
 
-   ````{tab} Ubuntu/Debian
+   ````{tab} Ubuntu/Debian/WSL
    ```console
    $ sudo apt update
    $ sudo apt install build-essential git python3.10
@@ -27,8 +27,49 @@ If you're using Arch Linux or one of its derivatives, we assume you have the
    $ yay -S python310
    ```
    ````
+2. If you're using an Nvidia GPU, install CUDA Toolkit 11.8 and cuDNN.
 
-2. Install `pipx` by following 
+   First, install and/or update your GPU drivers at
+   [this link](https://www.nvidia.com/Download/index.aspx). Select your GPU
+   model and click "Search", then click "Download". After installing the
+   drivers, reboot your system to ensure they take effect.
+
+   Then, install [CUDA Toolkit 11.8](https://developer.nvidia.com/cuda-11-8-0-download-archive?target_os=Linux&target_arch=x86_64).
+   Select your version of Linux, then follow the instructions to install CUDA
+   for your operating system.
+
+   To verify your installation of CUDA, use the following command.
+
+   ```pwsh-session
+   > nvcc --version
+   nvcc: NVIDIA (R) Cuda compiler driver
+   Copyright (c) 2005-2022 NVIDIA Corporation
+   Built on Wed_Sep_21_10:41:10_Pacific_Daylight_Time_2022
+   Cuda compilation tools, release 11.8, V11.8.89
+   Build cuda_11.8.r11.8/compiler.31833905_0
+   ```
+
+   ```{note}
+   If you run into issues installing CUDA, check out these resources:
+    - [CUDA Installation Documentation](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#package-manager-installation)
+      (these instructions are for the latest version of CUDA, so make sure to 
+      refer to the previous link for instructions specific to CUDA 11.8)
+    - [Detailed instructions for Ubuntu](https://gist.github.com/MihailCosmin/affa6b1b71b43787e9228c25fe15aeba)
+      (ignore the PyTorch installation instructions at the bottom, as LabGym
+      requires specific versions of PyTorch specified below)
+    - [Detailed instructions for WSL](https://rachitsingh.com/notes/wsl-cuda/)
+      (ignore the TensorRT and Python packages instructions at the bottom)
+   ```
+
+   Finally, install cuDNN by following [these instructions](https://docs.nvidia.com/deeplearning/cudnn/installation/linux.html#installing-on-linux). 
+   Scroll down until you see instructions for your operating system, then
+   follow them. You will need to register an Nvidia Developer account, which 
+   you can do for free.
+
+   As of February 2024, the latest version is cuDNN 9.0.0, which is compatible
+   with CUDA 11.8.
+
+3. Install `pipx` by following 
    [these instructions](https://pipx.pypa.io/stable/installation/). 
    
    To test your installation of `pipx`, close and reopen your terminal window,
@@ -41,19 +82,30 @@ If you're using Arch Linux or one of its derivatives, we assume you have the
    If the version number prints successfully, then your installation is working
    properly. Otherwise, try running the `pipx ensurepath` command again.
 
-3. Install LabGym via `pipx`.
+4. Install LabGym via `pipx`.
    
    ```console
    $ pipx install --python python3.10 LabGym
    ```
+6. Install PyTorch in LabGym's virtual environment.
 
-4. Install [Detectron2][] in the LabGym's virtual environment.
+   ```pwsh-session
+   > pipx inject --index-url https://download.pytorch.org/whl/cu118 LabGym torch=2.0.1 torchvision=0.15.2
+   ```
+
+   If you are using LabGym without a GPU, use the following command instead.
+
+   ```pwsh-session
+   > pipx inject --index-url https://download.pytorch.org/whl/cpu LabGym torch=2.0.1 torchvision=0.15.2
+   ```
+
+5. Install [Detectron2][] in the LabGym's virtual environment.
    
    ```console
    $ pipx runpip LabGym install 'git+https://github.com/facebookresearch/detectron2.git'
    ```
 
-5. Launch LabGym.
+6. Launch LabGym.
 
    ```console
    $ LabGym

--- a/docs/installation/linux.md
+++ b/docs/installation/linux.md
@@ -1,4 +1,4 @@
-# Linux/WSL2
+# Linux/WSL
 
 Depending on which distribution of Linux you use, the process of installing
 packages will look slightly different. Select the appropriate distribution

--- a/docs/installation/windows.md
+++ b/docs/installation/windows.md
@@ -4,6 +4,13 @@ To install LabGym on Windows, you will need to access the terminal. To do this,
 open the start menu by clicking the `Win` key, type "PowerShell", and hit
 enter. All terminal commands going forward should be entered in this terminal.
 
+```{warning}
+There is a known issue with LabGym that prevents it from running on Windows 11. 
+If you are on Windows 11, we suggest using 
+[Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install) 
+and following along with the [Linux installation instructions](./linux).
+```
+
 1. Install [Git][]. 
 
    If you're unsure of which installation method to use, select the `64-bit Git

--- a/docs/installation/windows.md
+++ b/docs/installation/windows.md
@@ -34,6 +34,47 @@ enter. All terminal commands going forward should be entered in this terminal.
    Python 3.10.10
    ```
 
+4. If you're using an Nvidia GPU, install CUDA Toolkit 11.8 and cuDNN.
+
+   First, install and/or update your GPU drivers at
+   [this link](https://www.nvidia.com/Download/index.aspx). Select your GPU
+   model and click "Search", then click "Download". After installing the
+   drivers, reboot your system to ensure they take effect.
+
+   Then, install [CUDA Toolkit 11.8](https://developer.nvidia.com/cuda-11-8-0-download-archive?target_os=Windows&target_arch=x86_64).
+   Select your version of Windows, select "exe (local)," then click "Download."
+
+   ```{warning}
+   If you're using Windows Subsystem for Linux (WSL), please refer to the 
+   [Linux](linux) install instructions.
+   ```
+
+   To verify your installation of CUDA, use the following command.
+
+   ```pwsh-session
+   > nvcc --version
+   nvcc: NVIDIA (R) Cuda compiler driver
+   Copyright (c) 2005-2022 NVIDIA Corporation
+   Built on Wed_Sep_21_10:41:10_Pacific_Daylight_Time_2022
+   Cuda compilation tools, release 11.8, V11.8.89
+   Build cuda_11.8.r11.8/compiler.31833905_0
+   ```
+
+   Finally, install [cuDNN](https://developer.nvidia.com/cudnn-downloads?target_os=Windows&target_arch=x86_64). 
+   You will need to register an Nvidia Developer account, which you can do for
+   free.
+
+   ```{important}
+   If you're using Windows 11, when installing cuDNN, select "Tarball" then 
+   "11" under CUDA Version. Then, follow
+   [these instructions](https://docs.nvidia.com/deeplearning/cudnn/installation/windows.html#installing-on-windows)
+   to install cuDNN from the `.tar.gz` file.
+   ```
+
+   As of February 2024, the latest version is cuDNN 9.0.0, which is compatible
+   with CUDA 11.8.
+
+
 4. Install `pipx` by following 
    [these instructions](https://pipx.pypa.io/stable/installation/).
    
@@ -53,7 +94,19 @@ enter. All terminal commands going forward should be entered in this terminal.
    > pipx install --python 3.10 LabGym
    ```
 
-6. Install [Detectron2][] in the LabGym's virtual environment.
+6. Install PyTorch in LabGym's virtual environment.
+
+   ```pwsh-session
+   > pipx inject --index-url https://download.pytorch.org/whl/cu118 LabGym torch=2.0.1 torchvision=0.15.2
+   ```
+
+   If you are using LabGym without a GPU, use the following command instead.
+
+   ```pwsh-session
+   > pipx inject --index-url https://download.pytorch.org/whl/cpu LabGym torch=2.0.1 torchvision=0.15.2
+   ```
+
+6. Install [Detectron2][] in LabGym's virtual environment.
    
    ```pwsh-session
    > pipx runpip LabGym install 'git+https://github.com/facebookresearch/detectron2.git'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,10 @@ authors = [
     {name = "Isabelle Baker", email = "ibaker@umich.edu"},
 ]
 dependencies = [
-    "tensorflow>=2.15.0",
+    # Windows-native GPU support ended with TensorFlow 2.11, so use 2.10
+    # on Windows and any version on other platforms
+    "tensorflow>=2.10.1; platform_system != 'Windows'",
+    "tensorflow<2.11; platform_system == 'Windows'",
     "matplotlib>=3.8.2",
     "opencv-contrib-python>=4.9.0.80",
     "openpyxl>=3.1.2",
@@ -24,8 +27,15 @@ dependencies = [
     "seaborn>=0.13.1",
     "wxPython>=4.2.1",
     "scikit-posthocs>=0.8.1",
-    "torch>=2.1.2",
-    "torchvision>=0.16.2",
+    # torch and torchvision are pinned to support Detectron2.
+    # We need torch compiled with CUDA 11.8, which is only available from
+    # PyTorch's version of PyPI. On macOS, since there is no support for CUDA,
+    # we can install directly from PyPI.
+    # If we try to include the PyTorch repository URL in pyproject.toml, PyPI 
+    # won't accept LabGym for security reasons. So, users need to install torch 
+    # separately before building Detectron2 as per the documentation.
+    "torch==2.0.1 ; platform_system == 'Darwin'",
+    "torchvision==0.15.2 ; platform_system == 'Darwin'",
     "packaging>=23.2",
 ]
 requires-python = ">=3.9,<3.11"


### PR DESCRIPTION
This PR makes several changes to how dependencies are installed so that TensorFlow and PyTorch work with GPU support. In particular:

 - On Windows-native, TensorFlow 2.10.1 is installed to ensure GPU support. On all other platforms, the latest version (2.15) is installed.
 - PyTorch is pinned to 2.0.1 and is only automatically installed on macOS. For GPU support with CUDA 11.8, users now use `pipx inject` to install version 2.0.1 compiled with CUDA 11.8.
 - Users are now instructed to install CUDA 11.8 and cuDNN 9.0.0, and the documentation now links to resources to assist with issues installing CUDA.