### PR TITLE
Remove all references to `THE_ABSOLUTE_CURRENT_PATH`

### DIFF
--- a/LabGym/gui/analysis/analyze_behaviors.py
+++ b/LabGym/gui/analysis/analyze_behaviors.py
@@ -25,8 +25,12 @@ import torch
 import wx
 
 from LabGym.analyzebehaviors import AnalyzeAnimal
-from LabGym.analyzebehaviorsdetector import DETECTOR_FOLDER, AnalyzeAnimalDetector
-from LabGym.categorizers import CATEGORIZER_FOLDER
+from LabGym.analyzebehaviorsdetector import (
+    DETECTOR_FOLDER,
+    AnalyzeAnimalDetector,
+    get_detector_names,
+)
+from LabGym.categorizers import CATEGORIZER_FOLDER, get_categorizer_names
 from LabGym.gui.utils import WX_IMAGE_WILDCARD, WX_VIDEO_WILDCARD, LabGymWindow
 from LabGym.tools import plot_evnets
 
@@ -195,17 +199,7 @@ class AnalyzeBehaviors(LabGymWindow):
         self.display_window()
 
     def select_categorizer(self, event):
-        categorizers = [
-            i
-            for i in os.listdir(str(CATEGORIZER_FOLDER))
-            if os.path.isdir(os.path.join(str(CATEGORIZER_FOLDER), i))
-        ]
-        if "__pycache__" in categorizers:
-            categorizers.remove("__pycache__")
-        if "__init__" in categorizers:
-            categorizers.remove("__init__")
-        if "__init__.py" in categorizers:
-            categorizers.remove("__init__.py")
+        categorizers = get_categorizer_names()
         categorizers.sort()
         if (
             "No behavior classification, just track animals and quantify motion kinematics"
@@ -655,17 +649,7 @@ class AnalyzeBehaviors(LabGymWindow):
                 self.use_detector = True
                 self.animal_number = {}
 
-                detectors = [
-                    i
-                    for i in os.listdir(str(DETECTOR_FOLDER))
-                    if os.path.isdir(os.path.join(str(DETECTOR_FOLDER), i))
-                ]
-                if "__pycache__" in detectors:
-                    detectors.remove("__pycache__")
-                if "__init__" in detectors:
-                    detectors.remove("__init__")
-                if "__init__.py" in detectors:
-                    detectors.remove("__init__.py")
+                detectors = get_detector_names()
                 detectors.sort()
                 if "Choose a new directory of the Detector" not in detectors:
                     detectors.append("Choose a new directory of the Detector")

--- a/LabGym/gui/analysis/analyze_behaviors.py
+++ b/LabGym/gui/analysis/analyze_behaviors.py
@@ -242,16 +242,16 @@ class AnalyzeBehaviors(LabGymWindow):
                     0,
                     100,
                 )
-                if dialog1.ShowModal() == wx.ID_OK:
+                if dialog1.ShowModal() != wx.ID_OK:
+                    dialog1.Destroy()
+                    return
+                else:
                     uncertain = dialog1.GetValue()
                     self.uncertain = uncertain / 100
-                dialog1.Destroy()
+                    dialog1.Destroy()
+
                 self.text_selectcategorizer.SetLabel(
-                    "The path to the Categorizer is: "
-                    + self.path_to_categorizer
-                    + " with uncertainty of "
-                    + str(uncertain)
-                    + "%."
+                    f"The path to the Categorizer is {self.path_to_categorizer} with uncertainty of {uncertain} %."
                 )
             elif (
                 categorizer

--- a/LabGym/gui/analysis/analyze_behaviors.py
+++ b/LabGym/gui/analysis/analyze_behaviors.py
@@ -18,7 +18,6 @@ Email: bingye@umich.edu
 
 import json
 import os
-from pathlib import Path
 
 import matplotlib as mpl
 import pandas as pd
@@ -26,11 +25,10 @@ import torch
 import wx
 
 from LabGym.analyzebehaviors import AnalyzeAnimal
-from LabGym.analyzebehaviorsdetector import AnalyzeAnimalDetector
+from LabGym.analyzebehaviorsdetector import DETECTOR_FOLDER, AnalyzeAnimalDetector
+from LabGym.categorizers import CATEGORIZER_FOLDER
 from LabGym.gui.utils import WX_IMAGE_WILDCARD, WX_VIDEO_WILDCARD, LabGymWindow
 from LabGym.tools import plot_evnets
-
-the_absolute_current_path = str(Path(__file__).resolve().parent.parent.parent)
 
 
 class ColorPicker(wx.Dialog):
@@ -61,7 +59,6 @@ class AnalyzeBehaviors(LabGymWindow):
         super().__init__(title="Analyze Behaviors", size=(1000, 600))
         self.behavior_mode = 0
         self.use_detector = False
-        self.detector_path = None
         self.path_to_detector = None
         self.detector_batch = 1
         self.detection_threshold = 0
@@ -69,7 +66,6 @@ class AnalyzeBehaviors(LabGymWindow):
         self.background_path = (
             None  # if not None, will load background images from path
         )
-        self.model_path = None  # the parent path of the Categorizers
         self.path_to_categorizer = None
         self.path_to_videos = None
         self.result_path = None
@@ -199,13 +195,10 @@ class AnalyzeBehaviors(LabGymWindow):
         self.display_window()
 
     def select_categorizer(self, event):
-        if self.model_path is None:
-            self.model_path = os.path.join(the_absolute_current_path, "models")
-
         categorizers = [
             i
-            for i in os.listdir(self.model_path)
-            if os.path.isdir(os.path.join(self.model_path, i))
+            for i in os.listdir(str(CATEGORIZER_FOLDER))
+            if os.path.isdir(os.path.join(str(CATEGORIZER_FOLDER), i))
         ]
         if "__pycache__" in categorizers:
             categorizers.remove("__pycache__")
@@ -288,7 +281,9 @@ class AnalyzeBehaviors(LabGymWindow):
                     "No behavior classification. Just track animals and quantify motion kinematics."
                 )
             else:
-                self.path_to_categorizer = os.path.join(self.model_path, categorizer)
+                self.path_to_categorizer = os.path.join(
+                    str(CATEGORIZER_FOLDER), categorizer
+                )
                 dialog1 = wx.NumberEntryDialog(
                     self,
                     "Enter the Categorizer's uncertainty level (0~100%)",
@@ -659,14 +654,11 @@ class AnalyzeBehaviors(LabGymWindow):
             else:
                 self.use_detector = True
                 self.animal_number = {}
-                self.detector_path = os.path.join(
-                    the_absolute_current_path, "detectors"
-                )
 
                 detectors = [
                     i
-                    for i in os.listdir(self.detector_path)
-                    if os.path.isdir(os.path.join(self.detector_path, i))
+                    for i in os.listdir(str(DETECTOR_FOLDER))
+                    if os.path.isdir(os.path.join(str(DETECTOR_FOLDER), i))
                 ]
                 if "__pycache__" in detectors:
                     detectors.remove("__pycache__")
@@ -695,7 +687,7 @@ class AnalyzeBehaviors(LabGymWindow):
                         dialog2.Destroy()
                     else:
                         self.path_to_detector = os.path.join(
-                            self.detector_path, detector
+                            str(DETECTOR_FOLDER), detector
                         )
                     with open(
                         os.path.join(self.path_to_detector, "model_parameters.txt")

--- a/LabGym/gui/training/behavior_examples.py
+++ b/LabGym/gui/training/behavior_examples.py
@@ -30,6 +30,7 @@ from cv2.typing import MatLike
 
 from LabGym.analyzebehaviors import AnalyzeAnimal
 from LabGym.analyzebehaviorsdetector import (
+    DETECTOR_FOLDER,
     AnalyzeAnimalDetector,
     get_animal_names,
     get_detector_names,
@@ -42,8 +43,6 @@ from LabGym.gui.utils import (
 )
 from LabGym.tools import AnimalVsBg
 
-THE_ABSOLUTE_CURRENT_PATH = str(Path(__file__).resolve().parent.parent.parent)
-
 
 class GenerateBehaviorExamples(LabGymWindow):
     """Generate behavior examples for the user to sort."""
@@ -52,7 +51,6 @@ class GenerateBehaviorExamples(LabGymWindow):
         super().__init__(title="Generate Behavior Examples", size=(1000, 530))
         self.behavior_mode = BehaviorMode.NON_INTERACTIVE
         self.use_detector = False
-        self.detector_path = None
         self.path_to_detector = None
         self.detection_threshold = 0
         self.animal_kinds = []
@@ -439,7 +437,6 @@ class GenerateBehaviorExamples(LabGymWindow):
         """Configure Detector-based example generation."""
         self.use_detector = True
         self.animal_number = {}
-        self.detector_path = os.path.join(THE_ABSOLUTE_CURRENT_PATH, "detectors")
 
         detectors = get_detector_names()
         detectors.append("Choose a new directory of the Detector")
@@ -465,7 +462,7 @@ class GenerateBehaviorExamples(LabGymWindow):
                 self.path_to_detector = dialog2.GetPaths()
             dialog2.Destroy()
         else:
-            self.path_to_detector = os.path.join(self.detector_path, detector)
+            self.path_to_detector = os.path.join(str(DETECTOR_FOLDER), detector)
 
         animal_names = get_animal_names(detector)
         if len(animal_names) > 1:

--- a/LabGym/gui/training/categorizers.py
+++ b/LabGym/gui/training/categorizers.py
@@ -2,7 +2,7 @@
 Copyright (C)
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-You should have received a copy of the GNU General Public License along with this program. If not, see https://tldrlegal.com/license/gnu-general-public-license-v3-(gpl-3)#fulltext. 
+You should have received a copy of the GNU General Public License along with this program. If not, see https://tldrlegal.com/license/gnu-general-public-license-v3-(gpl-3)#fulltext.
 
 For license issues, please contact:
 
@@ -16,16 +16,17 @@ USA
 Email: bingye@umich.edu
 """
 
-
 import os
-from pathlib import Path
 
 import wx
 
-from LabGym.categorizers import Categorizers, delete_categorizer, get_categorizer_names
+from LabGym.categorizers import (
+    CATEGORIZER_FOLDER,
+    Categorizers,
+    delete_categorizer,
+    get_categorizer_names,
+)
 from LabGym.gui.utils import BehaviorMode, LabGymWindow
-
-the_absolute_current_path = str(Path(__file__).resolve().parent.parent.parent)
 
 
 class TrainCategorizers(LabGymWindow):
@@ -47,7 +48,6 @@ class TrainCategorizers(LabGymWindow):
         aug_methods: A list of augmentation methods to use while training.
         augvalid: Whether or not to use augmentation for validation data.
         data_path: The path to all prepared training examples.
-        model_path: The location of the available categorizers.
         path_to_categorizer: The path to the newly created categorizer.
         training_report_path: The folder in which to store training reports.
         include_bodyparts: Whether or not to include body parts.
@@ -73,10 +73,7 @@ class TrainCategorizers(LabGymWindow):
         self.aug_methods = []
         self.augvalid = True
         self.data_path = None
-        self.model_path = os.path.join(the_absolute_current_path, "models")
-        self.path_to_categorizer = os.path.join(
-            the_absolute_current_path, "models", "New_model"
-        )
+        self.path_to_categorizer = os.path.join(str(CATEGORIZER_FOLDER), "New_model")
         self.training_report_path = None
         self.include_bodyparts = False
         self.std = 0
@@ -620,7 +617,9 @@ class TrainCategorizers(LabGymWindow):
                 )
                 continue
 
-            self.path_to_categorizer = os.path.join(self.model_path, dialog.GetValue())
+            self.path_to_categorizer = os.path.join(
+                str(CATEGORIZER_FOLDER), dialog.GetValue()
+            )
             os.makedirs(self.path_to_categorizer)
 
             if self.using_animation_analyzer is False:
@@ -677,7 +676,6 @@ class TestCategorizers(LabGymWindow):
     def __init__(self):
         super().__init__(title="Test Categorizers", size=(1000, 240))
         self.file_path = None
-        self.model_path = os.path.join(the_absolute_current_path, "models")
         self.path_to_categorizer = None
         self.out_path = None
 
@@ -766,7 +764,9 @@ class TestCategorizers(LabGymWindow):
                 f"The path to the Categorizer to test is: {self.path_to_categorizer}."
             )
         else:
-            self.path_to_categorizer = os.path.join(self.model_path, categorizer)
+            self.path_to_categorizer = os.path.join(
+                str(CATEGORIZER_FOLDER), categorizer
+            )
             self.text_selectcategorizer.SetLabel(f"Categorizer to test: {categorizer}.")
 
     def select_filepath(self, event):


### PR DESCRIPTION
In order to maintain separation between the GUI code and the backend, the GUI should not need to know where on the filesystem the Detectors and Categorizers are located. By defining these folders in one place (`analyzebehaviorsdetectors.py` and `categorizers.py`, respectively), it reduces the chances for path-related bugs to arise in the GUI code.