### PR TITLE
Fix unit test

### DIFF
--- a/LabGym/analyzebehavior.py
+++ b/LabGym/analyzebehavior.py
@@ -16,10 +16,18 @@ USA
 Email: bingye@umich.edu
 '''
 
+# Log the load of this module (by the module loader, on first import).
+# Intentionally positioning these statements before other imports, against the
+# guidance of PEP-8, to log the load before other imports log messages.
+import logging
+logger =  logging.getLogger(__name__)
+logger.debug('loading %s', __file__)
 
 
 
+logger.debug('importing tools (starting...)')
 from .tools import *
+logger.debug('importing tools (done)')
 import os
 import gc
 import cv2

--- a/LabGym/mylogging.py
+++ b/LabGym/mylogging.py
@@ -75,6 +75,8 @@ For Example 3,
     DEBUG:LabGym.__main__:__name__: 'LabGym.__main__'
 """  # noqa: E501
 
+from __future__ import annotations  # 3.9 needs this for some type annotations
+
 # standard library imports
 import inspect
 import logging.config

--- a/LabGym/tests/test_mylogging.py
+++ b/LabGym/tests/test_mylogging.py
@@ -26,39 +26,39 @@ class ValuesSubclass(Values):
 # mylogging.config() with opts dict like {'loggingconfigfile': ...}
 
 # 1. bad logginglevelname produces a pair of warning messages.
-def test_config_1(mocker):
-    # mock so that call to the genuine myargparse.parse_args mocked, to
-    # return a Values object with attr logginglevelname = 'ALFA'
-    #
-    # mock_result = mocker.Mock()
-    # mock_result.loggingconfig = None
-    # mock_result.logginglevelname = None
-
-    # valobj = Values()
-    # # valobj.logginglevelname = 'ALFA'
-    # valobj.__dict__.update({'logginglevelname': 'ALFA'})
+def test_config_1(monkeypatch):
+    # Arrange
     valobj = ValuesSubclass({'logginglevelname': 'ALFA'})
-    print(f'D: valobj.__dict__, {valobj.__dict__!r}')
+    # print(f'DEBUG: valobj.__dict__, {valobj.__dict__!r}')
+    monkeypatch.setattr(
+        'LabGym.mylogging.myargparse.parse_args', 
+        lambda: valobj)
 
-    mocker.patch('LabGym.mylogging.myargparse.parse_args', return_value=valobj)
+    # Act
     logrecords = []
     mylogging.config(logrecords)
-
     mylogging.handle(logrecords)
+
+    # Assert
     # WARNING	mylogging	module 'logging' has no attribute 'ALFA'
     # WARNING	mylogging	Trouble overriding root logger level.
 
 
 # 2. bad configfile name produces a pair of warning messages.
-def test_config_2(mocker):
+def test_config_2(monkeypatch):
+    # Arrange
     valobj = ValuesSubclass({'loggingconfig': '/bravo/charlie.yaml'})
-    print(f'D: valobj.__dict__, {valobj.__dict__!r}')
+    # print(f'DEBUG: valobj.__dict__, {valobj.__dict__!r}')
+    monkeypatch.setattr(
+        'LabGym.mylogging.myargparse.parse_args', 
+        lambda: valobj)
 
-    mocker.patch('LabGym.mylogging.myargparse.parse_args', return_value=valobj)
+    # Act
     logrecords = []
     mylogging.config(logrecords)
-
     mylogging.handle(logrecords)
+
+    # Assert
     # WARNING	mylogging	[Errno 2] No such file or directory: '/bravo/charlie.yaml'
     # WARNING	mylogging	Trouble configuring logging...  Calling logging.basicConfig(level=logging.DEBUG)
 

--- a/LabGym/tools.py
+++ b/LabGym/tools.py
@@ -16,17 +16,23 @@ USA
 Email: bingye@umich.edu
 '''
 
-
-
-
+# Log the load of this module (by the module loader, on first import).
+# Intentionally positioning these statements before other imports, against the
+# guidance of PEP-8, to log the load before other imports log messages.
 import logging
+logger =  logging.getLogger(__name__)
+logger.debug('loading %s', __file__)
+
+
 import os
 import gc
 import cv2
 import numpy as np
 import datetime
 from skimage import exposure
+logger.debug('importing tensorflow.keras.preprocessing.image (starting...)')
 from tensorflow.keras.preprocessing.image import img_to_array
+logger.debug('importing tensorflow.keras.preprocessing.image (done)')
 from collections import deque
 import matplotlib.pyplot as plt
 from matplotlib.colors import LinearSegmentedColormap,Normalize
@@ -37,10 +43,6 @@ import functools
 import operator
 import math
 import shutil
-
-
-logger = logging.getLogger(__name__)
-
 
 
 def extract_background(frames,stable_illumination=True,animal_vs_bg=0):


### PR DESCRIPTION
This PR does two things.
1. fixes tests/test_mylogging.py to use monkeypatch instead of mock.  When tests/test_mylogging.py was written, pytest-mock was in the venv.  This change helps avoid adding an unnecessary dependency.
2. Added logging crumbs to 2 files, analyze_behavior.py and tools.py.  These helped isolate a protobuf compatibility issue during import tensorflow.keras.preprocessing.image.