### PR TITLE
New pytest to exercise imports

### DIFF
--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,55 +1,76 @@
+"""
+Load each of the package's top-level py-files.
+
+...namely, LabGym/*.py.
+These tests will expose basic syntax errors that prevent import.
+
+Some tests are specific to a set of py-files, possibly because they 
+require setup.
+
+The final test, test_remainder(), imports each of the remaining top-
+level py-files.
+The strength of this catch-all final test is that if a new top-level 
+py-file is introduced, full coverage is preserved and this test-file
+may still be suitable.
+"""
+
+import glob
+import importlib
+import logging
+import os
 import pprint
 import sys
 import textwrap
 
 
+submodules = []
+
+
 def test_import_LabGym_package():
-    '''
-    Ensures that the interpreter reads every file in LabGym,
-    which will catch basic syntax errors and compatibility errors between
-    Python 3.9 and 3.10.
-    '''
-
+    """Load LabGym.__init__.py and get a list of submodules."""
     import LabGym
-    print(f'sys.modules: {pprint.pformat(sys.modules)}')
+
+    # Confirm the assumption that under pytest, cwd is LabGym package's 
+    # parent dir (the repo dir).
+    assert os.getcwd() == os.path.dirname(os.path.dirname(LabGym.__file__))
+
+    # Prepare a list of all submodule py-files in LabGym dir, but not subdirs.
+    pyfiles = glob.glob(os.path.join(os.path.dirname(LabGym.__file__), '*.py'))
+    pyfiles.sort()  # result from glob.glob() isn't sorted
+    submodules.extend([os.path.basename(f).rstrip('.py') for f in pyfiles])
+    logging.debug('%s:\n%s', 'Milepost 0, submodules', 
+        textwrap.indent(pprint.pformat(submodules), '  '))
+
+    # Remove __init__.py.  There's no need to challenge it, as it was
+    # already loaded by the "import LabGym" statement at the beginning 
+    # of this in this test.
+    submodules.remove('__init__')
 
 
-def test_import_LabGym_submodules_alfa(monkeypatch):
-    # Arrange sys.argv.  Otherwise it contains pytest args, and
+def test_imports_with_sysargv_initialized(monkeypatch):
+    # Arrange sys.argv.  Otherwise sys.argv contains pytest args, and
     # myargparse raises an exception.
     monkeypatch.setattr(sys, 'argv', ['dummy'])
+
+    # Act
+    logging.info('import LabGym.__main__')
     import LabGym.__main__
+    submodules.remove('__main__')
 
-
-def test_import_LabGym_submodules_bravo():
-    # import LabGym.__main__
-    import LabGym.analyzebehavior
-    import LabGym.analyzebehavior_dt
-    print(f'sys.modules: {pprint.pformat(sys.modules)}')
-
-
-def test_import_LabGym_submodules_charlie():
-    import LabGym.categorizer
-    import LabGym.detector
-    import LabGym.gui_analyzer
-    print(f'sys.modules: {pprint.pformat(sys.modules)}')
-
-
-def test_import_LabGym_submodules_delta():
-    import LabGym.gui_categorizer
-    import LabGym.gui_detector
-    import LabGym.gui_main
-    print(f'sys.modules: {pprint.pformat(sys.modules)}')
-
-
-def test_import_LabGym_submodules_echo():
-    import LabGym.gui_preprocessor
-    import LabGym.minedata
+    logging.info('import LabGym.myargparse')
     import LabGym.myargparse
-    print(f'sys.modules: {pprint.pformat(sys.modules)}')
+    submodules.remove('myargparse')
 
 
-def test_import_LabGym_submodules_foxtrot():
-    import LabGym.mylogging
-    import LabGym.tools
-    print(f'sys.modules: {pprint.pformat(sys.modules)}')
+def test_remainder():
+    logging.debug('%s:\n%s', 'Milepost 1, submodules', 
+        textwrap.indent(pprint.pformat(submodules), '  '))
+
+    while len(submodules) > 0:
+        submodule = submodules[0]
+        logging.info(f"importlib.import_module('LabGym.{submodule}')")
+        importlib.import_module(f'LabGym.{submodule}')
+        submodules.pop(0)
+
+    logging.debug('%s:\n%s', 'Milepost 2, submodules', 
+        textwrap.indent(pprint.pformat(submodules), '  '))

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,0 +1,55 @@
+import pprint
+import sys
+import textwrap
+
+
+def test_import_LabGym_package():
+    '''
+    Ensures that the interpreter reads every file in LabGym,
+    which will catch basic syntax errors and compatibility errors between
+    Python 3.9 and 3.10.
+    '''
+
+    import LabGym
+    print(f'sys.modules: {pprint.pformat(sys.modules)}')
+
+
+def test_import_LabGym_submodules_alfa(monkeypatch):
+    # Arrange sys.argv.  Otherwise it contains pytest args, and
+    # myargparse raises an exception.
+    monkeypatch.setattr(sys, 'argv', ['dummy'])
+    import LabGym.__main__
+
+
+def test_import_LabGym_submodules_bravo():
+    # import LabGym.__main__
+    import LabGym.analyzebehavior
+    import LabGym.analyzebehavior_dt
+    print(f'sys.modules: {pprint.pformat(sys.modules)}')
+
+
+def test_import_LabGym_submodules_charlie():
+    import LabGym.categorizer
+    import LabGym.detector
+    import LabGym.gui_analyzer
+    print(f'sys.modules: {pprint.pformat(sys.modules)}')
+
+
+def test_import_LabGym_submodules_delta():
+    import LabGym.gui_categorizer
+    import LabGym.gui_detector
+    import LabGym.gui_main
+    print(f'sys.modules: {pprint.pformat(sys.modules)}')
+
+
+def test_import_LabGym_submodules_echo():
+    import LabGym.gui_preprocessor
+    import LabGym.minedata
+    import LabGym.myargparse
+    print(f'sys.modules: {pprint.pformat(sys.modules)}')
+
+
+def test_import_LabGym_submodules_foxtrot():
+    import LabGym.mylogging
+    import LabGym.tools
+    print(f'sys.modules: {pprint.pformat(sys.modules)}')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -20,13 +20,10 @@ Email: bingye@umich.edu
 
 
 def test_import_gui():
-
-	pass
-
 	'''
 	Ensures that the interpreter reads every file in LabGym,
 	which will catch basic syntax errors and compatibility errors between
 	Python 3.9 and 3.10.
 	'''
 
-	#from LabGym import gui_main  # noqa: F401
+	from LabGym import gui_main  # noqa: F401


### PR DESCRIPTION
This PR 
1. adds a new pytest test-file "test_imports.py".
2. uncomments the one line of "test_main.py" that actually challenges the package as was intended according to its docstring.  A developer might have commented it out because it is annoyingly slow... it can take several minutes.  But for the build-server that tries both Python 3.9 and 3.10, this should remain enabled.