### PR TITLE
Central logger queue instead of block

### DIFF
--- a/LabGym/__main__.py
+++ b/LabGym/__main__.py
@@ -84,6 +84,7 @@ def main():
 
 	gui_main.main_window()
 
+	logger.debug('Milestone -- exiting main')
 
 
 if __name__=='__main__':  # pragma: no cover

--- a/LabGym/central_logging.py
+++ b/LabGym/central_logging.py
@@ -9,6 +9,7 @@ Functions
 from __future__ import annotations
 
 # Standard library imports.
+import atexit
 import logging
 import logging.handlers
 import queue
@@ -18,6 +19,18 @@ import queue
 
 # Local application/library specific imports.
 from LabGym import config
+
+
+# cleanup should be registered with atexit if queueing is used.
+def cleanup(queue_listener):
+    try:
+        # print('logging.shutdown(): Calling')
+        logging.shutdown()  # ensure all buffered log records are processed.
+        # print('queue_listener.stop(): Calling...')
+        queue_listener.stop()  # shut down the listener thread.
+        # print('queue_listener.stop(): Returned')
+    except Exception as e:
+        print(f'Ignoring Exception: {e}')
 
 
 http_handler_config = {
@@ -131,6 +144,8 @@ def get_central_logger(http_handler_config=http_handler_config, reset=False):
     queue_listener = logging.handlers.QueueListener(logrecord_queue, 
         http_handler)
     queue_listener.start()  # Start the listener thread
+
+    atexit.register(cleanup, queue_listener)
 
     # Milestone -- logrecord handling is configured.
 


### PR DESCRIPTION
This PR implements queueing and async handling for log records created by the "Central Logger" which is sending data by HTTP Post to a remote central receiver.

This PR was tested (successfully) as follows:
1. modify the GCP central receiver source code to be deliberately slow, adding a 8 sec sleep in the POST processing.  
2. deploy/start the slow web service
3. add some extra central logging in master branch (temporarily)
4. run LabGym to demonstrate the slow web server impacts the timing of these checkpoints, spreading them out by 8 seconds each.
```
LabGym % LabGym 2>&1 | grep testpoint
2025-07-30 15:04:25	DEBUG	[4678505984:LabGym.probes:probes:88]	testpoint
2025-07-30 15:04:34	DEBUG	[4678505984:LabGym.probes:probes:90]	testpoint
2025-07-30 15:04:42	DEBUG	[4678505984:LabGym.probes:probes:92]	testpoint
2025-07-30 15:04:50	DEBUG	[4678505984:LabGym.probes:probes:94]	testpoint
2025-07-30 15:04:59	DEBUG	[4678505984:LabGym.probes:probes:96]	testpoint
```
(verified... slowness is observable in LabGym)

5. revert probes.py in master branch.  git checkout feature branch.  use modified probes.py.  Run with same test point timechecks, but with the code in this PR that makes logrecord handling for Central Logger happen in a different thread.
6. run LabGym to demonstrate the slow web server impacts the timing of these checkpoints, spreading them out by 8 seconds each.
```
% LabGym 2>&1 | grep testpoint
2025-07-30 15:13:31	DEBUG	[4516062720:LabGym.probes:probes:88]	testpoint
2025-07-30 15:13:31	DEBUG	[4516062720:LabGym.probes:probes:90]	testpoint
2025-07-30 15:13:31	DEBUG	[4516062720:LabGym.probes:probes:92]	testpoint
2025-07-30 15:13:31	DEBUG	[4516062720:LabGym.probes:probes:94]	testpoint
2025-07-30 15:13:31	DEBUG	[4516062720:LabGym.probes:probes:96]	testpoint
```
(verified: slowness is now NOT observable in LabGym.)

7. revert GCP central receiver to normal.