### PR TITLE
Register skip, dont ask again

### DIFF
--- a/LabGym/probes.py
+++ b/LabGym/probes.py
@@ -34,7 +34,7 @@ logger.debug('%s: %r', '(__name__, __package__)', (__name__, __package__))
 # Related third party imports.
 # import certifi  # Python package for providing Mozilla's CA Bundle.
 # import requests  # Python HTTP for Humans.
-# import packaging  # Core utilities for Python packages
+import packaging  # Core utilities for Python packages
 
 # Local application/library specific imports.
 from LabGym import __version__ as version
@@ -78,9 +78,44 @@ def probes() -> None:
              f' because registration_enable: {registration_enable}')
     else:
         # proceed with registration check
-        if not registration.is_registered():
+        #
+        # Either
+        # 1.  sw is registered.
+        #     is_registered() returns True.
+        # 2.  registration was skipped (with unchecked "Don't ask again").
+        #     is_registered() returns False.
+        # 3.  registration was skipped (with checked "Don't ask again").
+        #     Now user is running the same version of LabGym as when
+        #     registration was skipped.
+        #     is_registered() returns True.
+        #     Inspect reginfo['name'] and reginfo['version']
+        # 4.  registration was skipped (with checked "Don't ask again").
+        #     Now user is running a different version of LabGym as when
+        #     registration was skipped.
+        #     is_registered() returns True.
+        #     Inspect reginfo['name'] and reginfo['version']
+        #
+        # Note that is_registered() depends on
+        # <configdir>/registration.yaml.  If the setting for <configdir>
+        # is changed to a dir that doesn't have a registration.yaml,
+        # then is_registered() will return False.
+
+        reginfo = registration.get_reginfo_from_file()
+
+        # if user has skipped registration (with checked "Don't ask again")
+        # but that was selected in some different (earlier?) installation,
+        # then expire or void the "skip-henceforth" behavior.
+        skip_pass_void = (reginfo is not None
+            and reginfo.get('name') == 'skip'
+            and packaging.version.parse(version)
+                != packaging.version.parse(reginfo.get('version'))
+            )
+
+        # if not registration.is_registered():
+        if not registration.is_registered() or skip_pass_void:
             # Get reg info from user, store reginfo locally.  Also, send
-            # reginfo to central receiver via central_logger.
+            # reginfo to central receiver via central_logger (unless
+            # central_logger's disabled attribute is True).
             registration.register()
 
     # Report sw start and context to the central receiver.

--- a/LabGym/registration.py
+++ b/LabGym/registration.py
@@ -161,7 +161,8 @@ class RegFormDialog(wx.Dialog):
         main_sizer = wx.BoxSizer(wx.VERTICAL)
         input_sizer = wx.GridSizer(3, 2, 1, 1)  # rows, cols, vgap, hgap
         # button_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        button_sizer = wx.BoxSizer(wx.VERTICAL)
+        # button_sizer = wx.BoxSizer(wx.VERTICAL)
+        button_sizer = wx.GridSizer(2, 2, 1, 1)  # rows, cols, vgap, hgap
 
         text = wx.StaticText(self, label=header)
         main_sizer.Add(text,
@@ -191,12 +192,20 @@ class RegFormDialog(wx.Dialog):
         input_sizer.Add(self.input_email,
             1, wx.EXPAND)
 
+        # # Add buttons to the button sizer
+        # button_sizer.Add(self.register_button, 0, wx.ALL, 5)
+        # # Add a fixed-height spacer of 10 pixels
+        # button_sizer.Add((0, 10), 0)
+        # button_sizer.Add(self.skip_button, 0, wx.ALL, 5)
+        # # button_sizer.Add(self.my_checkbox, 0, wx.ALL | wx.ALIGN_CENTER_HORIZONTAL, 10)
+        # button_sizer.Add(self.my_checkbox, 0, wx.LEFT | wx.ALIGN_CENTER_HORIZONTAL, 5)
+
         # Add buttons to the button sizer
-        button_sizer.Add(self.register_button, 0, wx.ALL, 5)
-        # Add a fixed-height spacer of 10 pixels
-        button_sizer.Add((0, 10), 0)
+        button_sizer.Add(self.register_button, 0, wx.ALL|wx.ALIGN_RIGHT, 5)
         button_sizer.Add(self.skip_button, 0, wx.ALL, 5)
-        # button_sizer.Add(self.my_checkbox, 0, wx.ALL | wx.ALIGN_CENTER_HORIZONTAL, 10)
+        # Add a dummy empty spacer item
+        button_sizer.AddSpacer(0)  # leave this cell blank
+        # # button_sizer.Add(self.my_checkbox, 0, wx.ALL | wx.ALIGN_CENTER_HORIZONTAL, 10)
         button_sizer.Add(self.my_checkbox, 0, wx.LEFT | wx.ALIGN_CENTER_HORIZONTAL, 5)
 
         # Add sizers to main sizer

--- a/LabGym/registration.py
+++ b/LabGym/registration.py
@@ -159,15 +159,14 @@ class RegFormDialog(wx.Dialog):
 
         # Create sizers for layout
         main_sizer = wx.BoxSizer(wx.VERTICAL)
-        input_sizer = wx.GridSizer(3, 2, 1, 1)  # rows, cols, vgap, hgap
+        input_sizer = wx.FlexGridSizer(6, 2, 1, 1)  # rows, cols, vgap, hgap
         # button_sizer = wx.BoxSizer(wx.HORIZONTAL)
         # button_sizer = wx.BoxSizer(wx.VERTICAL)
-        button_sizer = wx.FlexGridSizer(2, 2, 1, 1)  # rows, cols, vgap, hgap
+        # button_sizer = wx.FlexGridSizer(2, 2, 1, 1)  # rows, cols, vgap, hgap
 
-        # # Allow column 1 to be shrinkable (even though proportion is 0 for items)
-        # # This allows it to shrink to the size of its content
-        # fgs.AddGrowableCol(1)
-        button_sizer.AddGrowableCol(0)
+        # Allow column 0 to be shrinkable (even though proportion is 0 for items)
+        # This allows it to shrink to the size of its content
+        input_sizer.AddGrowableCol(0)
 
         text = wx.StaticText(self, label=header)
         main_sizer.Add(text,
@@ -205,18 +204,22 @@ class RegFormDialog(wx.Dialog):
         # # button_sizer.Add(self.my_checkbox, 0, wx.ALL | wx.ALIGN_CENTER_HORIZONTAL, 10)
         # button_sizer.Add(self.my_checkbox, 0, wx.LEFT | wx.ALIGN_CENTER_HORIZONTAL, 5)
 
-        # Add buttons to the button sizer
-        button_sizer.Add(self.register_button, 0, wx.ALL|wx.ALIGN_RIGHT, 5)
-        button_sizer.Add(self.skip_button, 0, wx.ALL, 5)
+        # Add a row of dummy empty spacer items
+        input_sizer.Add((0,10), 0)  # add a fixed-height spacer of 10 pixels
+        input_sizer.AddSpacer(0)  # leave this cell blank
+
+        # Add buttons to the sizer
+        input_sizer.Add(self.register_button, 0, wx.ALL|wx.ALIGN_RIGHT, 5)
+        input_sizer.Add(self.skip_button, 0, wx.ALL, 5)
         # Add a dummy empty spacer item
-        button_sizer.AddSpacer(0)  # leave this cell blank
+        input_sizer.AddSpacer(0)  # leave this cell blank
         # # button_sizer.Add(self.my_checkbox, 0, wx.ALL | wx.ALIGN_CENTER_HORIZONTAL, 10)
-        button_sizer.Add(self.my_checkbox, 0, wx.LEFT | wx.ALIGN_CENTER_HORIZONTAL, 5)
+        input_sizer.Add(self.my_checkbox, 0, wx.LEFT | wx.ALIGN_CENTER_HORIZONTAL, 5)
 
         # Add sizers to main sizer
         main_sizer.Add(input_sizer, 1, wx.EXPAND | wx.ALL, 10)
-        main_sizer.Add(button_sizer,
-            0, wx.ALIGN_CENTER | wx.TOP | wx.BOTTOM, 10)
+        # main_sizer.Add(button_sizer,
+        #     0, wx.ALIGN_CENTER | wx.TOP | wx.BOTTOM, 10)
 
         self.SetSizerAndFit(main_sizer)
 

--- a/LabGym/registration.py
+++ b/LabGym/registration.py
@@ -148,12 +148,20 @@ class RegFormDialog(wx.Dialog):
 
         # Create buttons
         self.register_button = wx.Button(self, wx.ID_OK, "Register")
-        self.skip_button = wx.Button(self, wx.ID_CANCEL, "Skip")
+        fontsize = self.register_button.GetFont().GetPointSize()
+        logger.debug('%s: %r', 'fontsize + 2', fontsize + 2)
+        font = wx.Font(fontsize + 2, wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD)
+        self.register_button.SetFont(font)
+        self.skip_button = wx.Button(self, wx.ID_CANCEL, "Skip for now")
+
+        # Create the checkbox
+        self.my_checkbox = wx.CheckBox(self, label='Remember my choice, don\'t ask me again')
 
         # Create sizers for layout
         main_sizer = wx.BoxSizer(wx.VERTICAL)
         input_sizer = wx.GridSizer(3, 2, 1, 1)  # rows, cols, vgap, hgap
-        button_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        # button_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        button_sizer = wx.BoxSizer(wx.VERTICAL)
 
         text = wx.StaticText(self, label=header)
         main_sizer.Add(text,
@@ -185,7 +193,11 @@ class RegFormDialog(wx.Dialog):
 
         # Add buttons to the button sizer
         button_sizer.Add(self.register_button, 0, wx.ALL, 5)
+        # Add a fixed-height spacer of 10 pixels
+        button_sizer.Add((0, 10), 0)
         button_sizer.Add(self.skip_button, 0, wx.ALL, 5)
+        # button_sizer.Add(self.my_checkbox, 0, wx.ALL | wx.ALIGN_CENTER_HORIZONTAL, 10)
+        button_sizer.Add(self.my_checkbox, 0, wx.LEFT | wx.ALIGN_CENTER_HORIZONTAL, 5)
 
         # Add sizers to main sizer
         main_sizer.Add(input_sizer, 1, wx.EXPAND | wx.ALL, 10)

--- a/LabGym/registration.py
+++ b/LabGym/registration.py
@@ -223,13 +223,27 @@ class RegFormDialog(wx.Dialog):
 
         self.SetSizerAndFit(main_sizer)
 
-    def GetInputValues(self) -> dict | None:
-        """Return a dict containing the dialog object's input values."""
-        result = {
-            'name': self.input_name.GetValue(),
-            'affiliation': self.input_affiliation.GetValue(),
-            'email': self.input_email.GetValue(),
-            }
+    def GetInputValues(self, alt=None) -> dict | None:
+        """Return a dict containing the dialog object's input values.
+
+        If alt-behavior specified as 'skip', then return a dict of dummy val.
+        """
+        if alt is None:
+            result = {
+                'name': self.input_name.GetValue(),
+                'affiliation': self.input_affiliation.GetValue(),
+                'email': self.input_email.GetValue(),
+                }
+        elif alt == 'skip':
+            result = {
+                'name': 'skip',
+                'affiliation': 'skip',
+                'email': 'skip',
+                }
+        else:
+            # bad usage...
+            logger.warning('%s: %r', 'Unexpected!  alt', alt)
+            result = {}
         return result
 
     def bring_to_foreground(self) -> None:
@@ -301,7 +315,13 @@ def _get_reginfo_from_form() -> dict | None:
         else:
             logger.debug('%s -- %s', 'Milestone ShowModal', 'returned')
             logger.debug('User pressed [Skip]')
-            reginfo = None
+
+            if dlg.my_checkbox.GetValue():
+                logger.debug('Checked')
+                reginfo = dlg.GetInputValues('skip')
+            else:
+                logger.debug('Unchecked')
+                reginfo = None
 
     logger.debug('%s: %r', 'reginfo', reginfo)
     return reginfo

--- a/LabGym/registration.py
+++ b/LabGym/registration.py
@@ -162,7 +162,12 @@ class RegFormDialog(wx.Dialog):
         input_sizer = wx.GridSizer(3, 2, 1, 1)  # rows, cols, vgap, hgap
         # button_sizer = wx.BoxSizer(wx.HORIZONTAL)
         # button_sizer = wx.BoxSizer(wx.VERTICAL)
-        button_sizer = wx.GridSizer(2, 2, 1, 1)  # rows, cols, vgap, hgap
+        button_sizer = wx.FlexGridSizer(2, 2, 1, 1)  # rows, cols, vgap, hgap
+
+        # # Allow column 1 to be shrinkable (even though proportion is 0 for items)
+        # # This allows it to shrink to the size of its content
+        # fgs.AddGrowableCol(1)
+        button_sizer.AddGrowableCol(0)
 
         text = wx.StaticText(self, label=header)
         main_sizer.Add(text,

--- a/LabGym/registration.py
+++ b/LabGym/registration.py
@@ -1,4 +1,4 @@
-"""Provide functions to obtain and forward registration info.
+"""Provide functions to obtain, store, and forward registration info.
 
 "Public" Functions
     is_registered() -> bool
@@ -10,10 +10,31 @@
     get_reginfo_from_file() -> dict | None
         Load registration info from file, and return reginfo.
 
-Example
+Example 1
     import registration
 
     if not registration.is_registered():
+        # Get reg info from user, store reginfo locally.  Also, send
+        # reginfo to central receiver via central_logger (unless
+        # central_logger's disabled attribute is True).
+        registration.register()
+
+Example 2
+    import registration
+
+    reginfo = registration.get_reginfo_from_file()
+
+    # if user has skipped registration (with checked "Don't ask again")
+    # but that was selected in some different (earlier?) installation,
+    # then expire or void the "skip-henceforth" behavior.
+    skip_pass_void = (reginfo is not None
+        and reginfo.get('name') == 'skip'
+        and packaging.version.parse(version)
+            != packaging.version.parse(reginfo.get('version'))
+        )
+
+    # if not registration.is_registered():
+    if not registration.is_registered() or skip_pass_void:
         # Get reg info from user, store reginfo locally.  Also, send
         # reginfo to central receiver via central_logger (unless
         # central_logger's disabled attribute is True).
@@ -28,24 +49,19 @@ Weaknesses
     *   This module file is long.  It should be refactored into a
         package with smaller module files.
 
-Notes
-    ...
-
 "Private" Functions
-These functions are implementation details and should not be relied upon
-by external code, as they might change without notice in future versions.
-By convention they are named with a single leading underscore ("_") to
-indicate to other programmers that they are intended for private or
-internal use.
+    These functions are implementation details and should not be relied
+    upon by external code, as they might change without notice in future
+    versions.
+    By convention they are named with a single leading underscore ("_")
+    to indicate to other programmers that they are intended for private
+    or internal use.
+
     _get_reginfo_from_form() -> dict | None
         Display a reg form, get user input, and return reginfo.
 
     _store_reginfo_to_file(reginfo: dict) -> None
         Store registration info to file in user's LabGym config directory.
-
-Should these classes be considered private?  I'm not seeing a public use case.
-    RegFormDialog(wx.Dialog)
-    NotEmptyValidator(wx.Validator)
 """
 
 # Allow use of newer syntax Python 3.10 type hints in Python 3.9.
@@ -88,7 +104,6 @@ class NotEmptyValidator(wx.Validator):
     (class purpose and functionality, and optionally its attributes and methods)
     """
     def __init__(self):
-#         wx.PyValidator.__init__(self)
         wx.Validator.__init__(self)
 
     def Clone(self):  # pylint: disable=invalid-name
@@ -150,21 +165,22 @@ class RegFormDialog(wx.Dialog):
         self.register_button = wx.Button(self, wx.ID_OK, "Register")
         fontsize = self.register_button.GetFont().GetPointSize()
         logger.debug('%s: %r', 'fontsize + 2', fontsize + 2)
-        font = wx.Font(fontsize + 2, wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD)
+        font = wx.Font(fontsize + 2,
+            wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD)
         self.register_button.SetFont(font)
         self.skip_button = wx.Button(self, wx.ID_CANCEL, "Skip for now")
 
         # Create the checkbox
-        self.my_checkbox = wx.CheckBox(self, label='Remember my choice, don\'t ask me again')
+        self.my_checkbox = wx.CheckBox(self,
+            label='Remember my choice, don\'t ask me again')
 
-        # Create sizers for layout
+        # Create sizers for layout.
+        # Buttons and checkbox will go in the same FlexGridSizer as the
+        # text input fields.
         main_sizer = wx.BoxSizer(wx.VERTICAL)
         input_sizer = wx.FlexGridSizer(6, 2, 1, 1)  # rows, cols, vgap, hgap
-        # button_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        # button_sizer = wx.BoxSizer(wx.VERTICAL)
-        # button_sizer = wx.FlexGridSizer(2, 2, 1, 1)  # rows, cols, vgap, hgap
 
-        # Allow column 0 to be shrinkable (even though proportion is 0 for items)
+        # Allow col 0 to be shrinkable (even though proportion is 0 for items)
         # This allows it to shrink to the size of its content
         input_sizer.AddGrowableCol(0)
 
@@ -173,13 +189,10 @@ class RegFormDialog(wx.Dialog):
             0,  # proportion (int).  0 means the item won't expand
                 # beyond its minimal size.
 
-            # # border on all sides, align left, and expand
-            # # wx.ALL | wx.EXPAND | wx.LEFT,
             # border on all sides, and align left
             wx.ALL | wx.LEFT,
 
-            10,  # width (in pixels) of the border specified by the
-                 # border flags
+            10,  # width (in pixels) of the borders specified
             )
 
         # Add input fields with labels to the input sizer
@@ -196,14 +209,6 @@ class RegFormDialog(wx.Dialog):
         input_sizer.Add(self.input_email,
             1, wx.EXPAND)
 
-        # # Add buttons to the button sizer
-        # button_sizer.Add(self.register_button, 0, wx.ALL, 5)
-        # # Add a fixed-height spacer of 10 pixels
-        # button_sizer.Add((0, 10), 0)
-        # button_sizer.Add(self.skip_button, 0, wx.ALL, 5)
-        # # button_sizer.Add(self.my_checkbox, 0, wx.ALL | wx.ALIGN_CENTER_HORIZONTAL, 10)
-        # button_sizer.Add(self.my_checkbox, 0, wx.LEFT | wx.ALIGN_CENTER_HORIZONTAL, 5)
-
         # Add a row of dummy empty spacer items
         input_sizer.Add((0,10), 0)  # add a fixed-height spacer of 10 pixels
         input_sizer.AddSpacer(0)  # leave this cell blank
@@ -213,13 +218,11 @@ class RegFormDialog(wx.Dialog):
         input_sizer.Add(self.skip_button, 0, wx.ALL, 5)
         # Add a dummy empty spacer item
         input_sizer.AddSpacer(0)  # leave this cell blank
-        # # button_sizer.Add(self.my_checkbox, 0, wx.ALL | wx.ALIGN_CENTER_HORIZONTAL, 10)
-        input_sizer.Add(self.my_checkbox, 0, wx.LEFT | wx.ALIGN_CENTER_HORIZONTAL, 5)
+        input_sizer.Add(self.my_checkbox,
+            0, wx.LEFT | wx.ALIGN_CENTER_HORIZONTAL, 5)
 
         # Add sizers to main sizer
         main_sizer.Add(input_sizer, 1, wx.EXPAND | wx.ALL, 10)
-        # main_sizer.Add(button_sizer,
-        #     0, wx.ALIGN_CENTER | wx.TOP | wx.BOTTOM, 10)
 
         self.SetSizerAndFit(main_sizer)
 


### PR DESCRIPTION
Henry asked for a mechanism for the user to suppress repeated followup attempts to register.
Although registering with false info would work (like "Boaty McBoatface") to give the equivalent anonymity and persistence, there is another way that doesn't leave a taste of fraud...

Let the user choose "Don't ask me again".

I have implemented this feature, by using a checkbox.  It's tested.
The skip-pass lasts until user begins using a new version of LabGym.
That is, skip doesn't last forever... there's a new chance to register when user switches LabGym version.
(If this expiration is undesirable, it's a one-liner to change so that a Don't ask again is not overridden by beginning to use a different LabGym version.)

New look (with checkbox) here:
<img width="536" height="414" alt="Screen Shot 2025-07-31 at 6 14 05 PM" src="https://github.com/user-attachments/assets/917a1b48-b247-4b74-a1e4-a6fc9ab4d203" />

Old look here:
<img width="535" height="404" alt="Screen Shot 2025-07-31 at 6 17 01 PM" src="https://github.com/user-attachments/assets/27cc43b0-8130-4cdb-a028-374a4f58dda1" />
