### PR TITLE
Refactor initial logging deferral

### DIFF
--- a/LabGym/__main__.py
+++ b/LabGym/__main__.py
@@ -19,10 +19,8 @@ Email: bingye@umich.edu
 # pylint: enable=line-too-long
 
 # Standard library imports.
-import inspect
 import logging
 from pathlib import Path
-import sys
 
 
 # block begin
@@ -52,7 +50,7 @@ from packaging import version  # Core utilities for Python packages
 from LabGym import __version__, gui_main, probes
 
 
-logger.debug('%s: %r', '(__name__, __package__', (__name__, __package__))
+logger.debug('%s: %r', '(__name__, __package__)', (__name__, __package__))
 
 
 def main():

--- a/LabGym/__main__.py
+++ b/LabGym/__main__.py
@@ -25,20 +25,23 @@ from pathlib import Path
 import sys
 
 
-# Log the loading of this module (by the module loader, on first import).
-# Configure the logging system.
-#
+# block begin
 # These statements are intentionally positioned before this module's
-# other imports (against the guidance of PEP 8), to log the load of this
-# module before other import statements are executed and potentially
-# produce their own log messages.
-logrecords = [logging.LogRecord(lineno=inspect.stack()[0].lineno,
-    level=logging.DEBUG, exc_info=None, name=__name__, pathname=__file__,
-    msg='%s', args=(f'loading {__file__}',),
-    )]
+# other imports (against the guidance of PEP 8), to log the loading of
+# this module before other import statements are executed and
+# potentially produce their own log messages.
+
 from LabGym import mylogging
-# Configure logging based on configfile, then handle list of logrecords.
-mylogging.configure(logrecords)
+# Collect logrecords and defer handling until logging is configured.
+mylogging.defer()
+
+# Log the loading of this module (by the module loader, on first import).
+logger = logging.getLogger(__name__)
+logger.debug('loading %s', __file__)
+
+# Configure logging based on configfile, then handle collected logrecords.
+mylogging.configure()
+# block end
 
 
 # Related third party imports.
@@ -49,7 +52,6 @@ from packaging import version  # Core utilities for Python packages
 from LabGym import __version__, gui_main, probes
 
 
-logger = logging.getLogger(__name__)
 logger.debug('%s: %r', '(__name__, __package__', (__name__, __package__))
 
 

--- a/LabGym/config.py
+++ b/LabGym/config.py
@@ -58,7 +58,7 @@ defaults = {
         Path(__file__).parent.joinpath('logging.yaml'),  # LabGym/logging.yaml
         ],
     # intentionally, no default specified here for logging_configfile
-    # intentionally, no default specified here for logging_levelname
+    # intentionally, no default specified here for logging_level
 
     'enable': {
         'central_logger': True,  # to disable central logger, user must opt out

--- a/LabGym/myargparse.py
+++ b/LabGym/myargparse.py
@@ -3,7 +3,7 @@
 What about repeated settings within command-line args?
 *   Processed left to right.
 
-*   In this implementation, rightmost overrides those to the left, 
+*   In this implementation, rightmost overrides those to the left,
     except --enable and --disable, which for different featurenames
     accumulates in the enable dict
     For example,
@@ -33,7 +33,7 @@ ResultType = Dict[str, Union[
     str,  # configdir, configfile, logging_configfile (specific)
     # List[Path], # logging_configfiles (potentials)
     List[str], # logging_configfiles (potentials)
-    str,  # logging_levelname
+    str,  # logging_level
     bool,  # anonymous
     Dict[str, bool],  # enable
     ]]
@@ -51,9 +51,9 @@ def parse_args() -> ResultType:
 
     The --enable FEATURE and --disable FEATURE provide a risk-mitigated
     approach to the introduction of new features or behaviors.
-    Introduce the feature defaulting to disabled, and support user 
+    Introduce the feature defaulting to disabled, and support user
     opt-in.
-    After achieving confidence in the feature, change the default to 
+    After achieving confidence in the feature, change the default to
     enabled, and support user opt-out.
 
     Notes
@@ -66,11 +66,11 @@ def parse_args() -> ResultType:
 
     *   As an arg is going through the pattern matching... if it doesn't
         begin with '-', it is considered the first positional command-
-        line arg, and ends the option processing.  
+        line arg, and ends the option processing.
 
     *   A '--' arg is recognized as separating options from positional
         command-line args.  The '--' arg is necessary if the first
-        positional command-line arg starts with '-', to prevent 
+        positional command-line arg starts with '-', to prevent
         processing it as an option.
     """
 
@@ -84,22 +84,22 @@ def parse_args() -> ResultType:
         Usage: {basename} [options]
 
         Options:
-          --anonymous           Send only anonymized stats to the 
+          --anonymous           Send only anonymized stats to the
                                 central receiver.
           --configdir DIR       Find LabGym config files in the config
                                 dir (default '~/.labgym')
           --configfile FILE     LabGym config file (default 'config.toml')
           --enable FEATURE      Enable FEATURE.
-          --debug               Equivalent to --logging_levelname DEBUG.
+          --debug               Equivalent to --logging_level DEBUG.
           --disable FEATURE     Disable FEATURE.
           -h, --help            Show this help message and exit.
           --logging_configfile FILE    Use FILE to configure the logging
                                 system instead of trying the defaults.
-          --logging_levelname LEVELNAME    Set the root logger's level
-                                to logging.LEVELNAME, where LEVELNAME is 
-                                a term recognized by the logging system, 
-                                like DEBUG, INFO, WARNING, or ERROR.
-          -v, --verbose         Equivalent to --logging_levelname DEBUG.
+          --logging_level LEVEL    Set the root logger's level to LEVEL,
+                                where LEVEL is a term recognized by the
+                                logging system, like DEBUG, INFO,
+                                WARNING, or ERROR.
+          -v, --verbose         Equivalent to --logging_level DEBUG.
           --version             Show the LabGym version and exit.
         """)
 
@@ -150,12 +150,12 @@ def parse_args() -> ResultType:
             result['logging_configfile'] = args[1]
             args = args[2:]  # shift 2
 
-        elif arg in ['--logging_levelname']:
-            result['logging_levelname'] = args[1]
+        elif arg in ['--logging_level']:
+            result['logging_level'] = args[1]
             args = args[2:]  # shift 2
 
         elif arg in ['--debug', '-v', '--verbose']:
-            result['logging_levelname'] = 'DEBUG'
+            result['logging_level'] = 'DEBUG'
             args = args[1:]  # shift 1
 
         # standard options

--- a/LabGym/mylogging.py
+++ b/LabGym/mylogging.py
@@ -2,12 +2,14 @@
 """Provide functions for configuring the logging system.
 
 Functions
-    configure -- Configure logging based on configfile, then handle list
-        of logrecords.
+    defer -- Ensure logrecords are being queued for later handling.
+    configure -- Configure logging based on configfile, then handle
+        deferred logrecords.
 
 Strengths
-  * The configure function is guarded, to log exceptions as warnings, and
-    discard them instead of propagate/re-raise them.
+  * The public functions (defer, configure) are guarded, to log
+    exceptions as warnings, and discard them instead of propagate/
+    re-raise them.
     Why?  Because for this sw, the logging is considered not-essential,
     so logging config trouble is intentionally not fatal.
 
@@ -54,30 +56,38 @@ References
     https://docs.python.org/3/howto/logging-cookbook.html#logging-cookbook
 
 Example 1
+    import logging
+
     # Configure the logging system.
     from LabGym.mylogging import mylogging
     mylogging.config()
 
+    logger = logging.getLogger(__name__)
+    logger.debug('Milestone')
+    logger.info('Milestone')
+    logger.warning('Milestone')
+    logger.error('Milestone')
+
 Example 2, Log the loading of this module, and configure the logging system.
     # Standard library imports.
-    import inspect
     import logging
     ...
 
-    # Log the loading of this module (by the module loader, on first import).
-    # Configure the logging system.
-    #
     # These statements are intentionally positioned before this module's
-    # other imports (against the guidance of PEP 8), to log the load of this
-    # module before other import statements are executed and potentially
-    # produce their own log messages.
-    logrecords = [logging.LogRecord(lineno=inspect.stack()[0].lineno,
-        level=logging.DEBUG, exc_info=None, name=__name__, pathname=__file__,
-        msg='%s', args=(f'loading {__file__}',),
-        )]
+    # other imports (against the guidance of PEP 8), to log the loading of
+    # this module before other import statements are executed and
+    # potentially produce their own log messages.
+
     from LabGym import mylogging
-    # Configure logging based on configfile, then handle list of logrecords.
-    mylogging.configure(logrecords)
+    # Collect logrecords and defer handling until logging is configured.
+    mylogging.defer()
+
+    # Log the loading of this module (by the module loader, on first import).
+    logger = logging.getLogger(__name__)
+    logger.debug('loading %s', __file__)
+
+    # Configure logging based on configfile, then handle collected logrecords.
+    mylogging.configure()
 
     # Related third party imports.
     ...
@@ -85,38 +95,7 @@ Example 2, Log the loading of this module, and configure the logging system.
     # Local application/library specific imports.
     ...
 
-    logger = logging.getLogger(__name__)
-
-    logger.debug('Milestone')
-    logger.info('Milestone')
-    logger.warning('Milestone')
-    logger.error('Milestone')
-
-The output depends on the configuration of the logging system.
-For Example 2 outputs,
-
-(a) If the default config file LabGym/logging.yaml is used, with root
-    logger level=INFO, then there is no console output of the DEBUG
-    messages.
-
-(b) If a modified config file is used (for example
-    ~/.LabGym/logging.yaml) with root logger level=DEBUG, or if command-
-    line arg --verbose is specified, then console output shows messages
-    like
-
-    2025-05-14 09:21:02     DEBUG   [4467582464:LabGym.__main__:__main__:28]        loading /Users/john/Public/LabGym/LabGym/__main__.py
-    2025-05-14 09:21:02     DEBUG   [4467582464:LabGym.mylogging:mylogging:291]     configfile: '/Users/john/.LabGym/logging.yaml'
-    2025-05-14 09:21:02     DEBUG   [4467582464:LabGym.mylogging:mylogging:295]     function get_configdict returned a result
-    2025-05-14 09:21:02     DEBUG   [4467582464:LabGym.__main__:__main__:38]        __name__: 'LabGym.__main__'
-
-(c) If no config file is found or the config file is fouled, then
-    console output shows messages like
-
-    DEBUG:LabGym.__main__:loading /Users/john/Public/LabGym/LabGym/__main__.py
-    DEBUG:LabGym.mylogging:configfile: '/Users/john/.LabGym/logging.toml'
-    WARNING:LabGym.mylogging:Expected '=' after a key in a key/value pair (at line 4, column 8)
-    WARNING:LabGym.mylogging:Trouble configuring logging.  Calling logging.basicConfig(level=logging.DEBUG)
-    DEBUG:LabGym.__main__:__name__: 'LabGym.__main__'
+    logger.debug'%s: %r', '(__name__, __package__', (__name__, __package__))
 """  # noqa: E501
 # pylint: enable=line-too-long
 
@@ -181,7 +160,7 @@ if development_mode:
 #             f'Continuing after non-fatal exception: {e}'))
 
 def _myLogRecord(myobj: str | Exception, level: int) -> logging.LogRecord:
-    """Return a LogRecord for a string or exception."""
+    """Return a LogRecord for a string or for an exception."""
 
     lineno = inspect.stack()[2].lineno  # type: ignore
 
@@ -192,27 +171,16 @@ def _myLogRecord(myobj: str | Exception, level: int) -> logging.LogRecord:
         exc_info=None, name=__name__, pathname=__file__,
         )
 
-    if prehandle_logrecords and level >= logger.getEffectiveLevel():
-        # for development only
-        #
-        # In general or production use, handling of this logrecord
-        # should be performed only later, after configuring logging.
-        #
-        # To assist debugging during development or maintenance of this
-        # module, handle this logrecord now also (producing redundant
-        # output).
-        logger.handle(logrecord)  # for development only
-
     return logrecord
 
 
 def _mywarning(myobj: str | Exception) -> logging.LogRecord:
-    """Return a WARNING LogRecord for a string or exception."""
+    """Return a WARNING LogRecord for a string or for an exception."""
     return _myLogRecord(myobj, level=logging.WARNING)
 
 
 def _mydebug(myobj: str | Exception) -> logging.LogRecord:
-    """Return a DEBUG LogRecord for a string or exception."""
+    """Return a DEBUG LogRecord for a string or for an exception."""
     return _myLogRecord(myobj, level=logging.DEBUG)
 
 
@@ -262,44 +230,14 @@ def catch_exceptions_and_warn(wrappee):
 @catch_exceptions_and_warn  # Guard from exceptions.
 def configure() -> None:
     """
-    Configure logging based on configfile, then handle collected logrecords.
+    Configure logging based on configfile, then handle deferred logrecords.
 
-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
-
-    (1) Initialize with logging module's basicConfig(), raiseExceptions,
-        and captureWarnings().
-    (2) Configure the logging system based on settings from a configfile.
-    (3) Honor command-line args that override the root logger level.
-    (4) After configuring, handle each logrecord in the list of
-        accumulated logrecords.
-
-
-    (1) Configure logging based on configfile, or fall back to
-        calling logging.basicConfig(level=logging.DEBUG).
-        Set logging.raiseExceptions to False.  (Why?  Because We want to
-        ignore handler-emit exceptions.)
-
-    (2) Redirect all warnings issued by the warnings module to the
-        logging system.
-
-    (3) After configuring the logging system per configfile, honor
-        command-line args that override the root logger level (-v,
-        --verbose, --logginglevel DEBUG).
-
-    While executing this function, append any new log records to
-    logrecords (for later handling).
-
-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+    (1) Configure the logging system based on settings from a configfile.
+    (2) Honor command-line args that override the root logger level.
+    (3) Handle the collected/deferred logrecords
     """
 
-    # (1) Initialize ...
-
-    # initialize the logging system.
-    # Remove pre-existing handlers from root logger, then basicConfig().
-    logging.getLogger().handlers = []
-    logging.basicConfig(level=logging.DEBUG)
-    defer()
-
+    rootlogger = logging.getLogger()
 
     # Set logging.raiseExceptions to False.
     # (Why?  Because we want to ignore handler emit exceptions.)
@@ -308,17 +246,21 @@ def configure() -> None:
     # Redirect warnings issued by the warning module to the logging system.
     logging.captureWarnings(True)
 
-    # (2) Configure the logging system based on settings from a configfile.
+    # (1) Configure the logging system based on settings from a configfile.
     try:
         defer()  # Ensure logrecords are being queued.
 
-        # Get all of the values needed from config.get_config().
+        # (1) Get all of the values needed from config.get_config().
         _config = config.get_config()
         logging_configfiles: List[Path] = _config['logging_configfiles']
         logging_configfile: Path|None = _config.get('logging_configfile')
         logging_levelname: str|None = _config.get('logging_levelname')
 
-        # if the config defines a specific logging_configfile, only
+        # Copy the queued logrecords to a list, and switch over to
+        # manual logrecord creation until configuring is completed.
+        logrecords = _get_logrecords_from_queue()
+
+        # if the config defines a specific logging_configfile, then only
         # attempt to use it.  Otherwise, step through the list of
         # logging_configfiles and try them until success.
 
@@ -352,9 +294,8 @@ def configure() -> None:
             f'Trouble configuring the logging system.  ({e})'))
         rootlogger.handlers = []
         logging.basicConfig(level=logging.DEBUG)
-        
 
-    # (3) Honor command-line args that override the root logger level.
+    # (2) Honor command-line args that override the root logger level.
     try:
         if logging_levelname is not None:
             logrecords.append(_mydebug(
@@ -368,10 +309,10 @@ def configure() -> None:
 
     # Milestone -- The logging system is configured.
 
-    _handle(logrecords)  # handle the collected/deferred logrecords
+    # (3) Handle the collected/deferred logrecords
+    _handle(logrecords)
 
 
-@catch_exceptions_and_warn  # Guard from exceptions.
 def _handle(logrecords: List[logging.LogRecord]) -> None:
     """For each collected/deferred logrecord, have its named logger handle it.
 
@@ -389,25 +330,10 @@ def _handle(logrecords: List[logging.LogRecord]) -> None:
 
 @catch_exceptions_and_warn  # Guard from exceptions.
 def defer():
-    """Ensure logrecords are being queued.
+    """Ensure logrecords are being queued for later handling.
 
-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-    Collect logrecords in a queue for handling after configuration.
-
-    Collect logrecords in a queue for handling after the logging system
-    has been been configured.
-
-    The intention is, for the time being,
-    collect logrecords in a queue without filtering,
-    and defer handling, with the intention of handling them after the
-    logging system is configured.
-
-    If handlers is an empty list, or contains only a nullhandler, then
-        add a queuehandler
-    elif handlers contains a queuehandler (and optionally others, like
-    else
-         unexpected
-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    After the specified logging configuration has been applied to the
+    logging system, function _handle will be called to handle logrecords.
     """
 
     rootlogger = logging.getLogger()
@@ -441,7 +367,7 @@ def defer():
 def _get_logrecords_from_queue():
     """Return a list of logrecords that were queued by the rootlogger.
 
-    Weaknesses: 
+    Weaknesses:
     1.  The expected usage is that the rootlogger has exactly one
         QueueHandler.  This function could be more defensive regarding
         confirming that expectation.

--- a/LabGym/mylogging.py
+++ b/LabGym/mylogging.py
@@ -18,8 +18,8 @@ Notes
     INFO) messages, despite the root logger set to higher-level (like
     WARNING).
 
-    If the user supplies command line args which set logginglevelname to
-    WARNING (like '--logginglevel WARNING'), the root logger level is
+    If the user supplies command line args which set logging_level to
+    WARNING (like '--logging_level WARNING'), the root logger level is
     set to logging.WARNING.
     The user might expect that setting root logger level to WARNING
     would suppress all INFO-level log messages from the console output,
@@ -254,7 +254,7 @@ def configure() -> None:
         _config = config.get_config()
         logging_configfiles: List[Path] = _config['logging_configfiles']
         logging_configfile: Path|None = _config.get('logging_configfile')
-        logging_levelname: str|None = _config.get('logging_levelname')
+        logging_level: str|None = _config.get('logging_level')
 
         # Copy the queued logrecords to a list, and switch over to
         # manual logrecord creation until configuring is completed.
@@ -297,10 +297,10 @@ def configure() -> None:
 
     # (2) Honor command-line args that override the root logger level.
     try:
-        if logging_levelname is not None:
+        if logging_level is not None:
             logrecords.append(_mydebug(
-                f'logging_levelname: {logging_levelname}'))
-            logging.getLogger().setLevel(getattr(logging, logging_levelname))
+                f'logging_level: {logging_level}'))
+            rootlogger.setLevel(logging_level)
 
     except Exception as e:
         # log the exception as a warning

--- a/LabGym/tests/test_myargparse.py
+++ b/LabGym/tests/test_myargparse.py
@@ -31,26 +31,26 @@ def test_parse_args_no_args(monkeypatch):
 def test_parse_args_verbose_then_info(monkeypatch):
     # Arrange
     monkeypatch.setattr(sys, 'argv',
-        ['cmd', '--verbose', '--logging_levelname', 'INFO'])
+        ['cmd', '--verbose', '--logging_level', 'INFO'])
 
     # Act
     result = myargparse.parse_args()
 
     # Assert
-    assert result == {'logging_levelname': 'INFO'}
+    assert result == {'logging_level': 'INFO'}
 
 
-# Args are parsed left-to-right, so logging_levelname gets DEBUG.
+# Args are parsed left-to-right, so logging_level gets DEBUG.
 def test_parse_args_info_then_verbose(monkeypatch):
     # Arrange
     monkeypatch.setattr(sys, 'argv',
-        ['cmd', '--logging_levelname', 'INFO', '--verbose'])
+        ['cmd', '--logging_level', 'INFO', '--verbose'])
 
     # Act
     result = myargparse.parse_args()
 
     # Assert
-    assert result == {'logging_levelname': 'DEBUG'}
+    assert result == {'logging_level': 'DEBUG'}
 
 
 # bad option
@@ -73,7 +73,7 @@ def test_parse_args_bad_option(monkeypatch):
 def test_parse_args_help(monkeypatch, capsys):
     # Arrange
     monkeypatch.setattr(sys, 'argv',
-        ['cmd', '--logging_levelname', 'ALFA', '-v', '--help', 'bravo'])
+        ['cmd', '--logging_level', 'ALFA', '-v', '--help', 'bravo'])
  
     # Act, and assert raises(SystemExit)
     with pytest.raises(SystemExit) as e:

--- a/LabGym/tests/test_mylogging.py
+++ b/LabGym/tests/test_mylogging.py
@@ -24,21 +24,20 @@ def test_success(monkeypatch):
         'logging_configfiles': 
             [Path(mylogging.__file__).parent.joinpath('logging.yaml')],
         'logging_configfile': None,
-        'logging_levelname': 'INFO',
+        'logging_level': 'INFO',
         }
     monkeypatch.setattr(mylogging.config, 'get_config', lambda: _config)
     logging.debug('%s: %r', '_config', _config)
 
     # Act
-    logrecords = []
-    mylogging.configure(logrecords)
+    mylogging.configure()
 
     # Assert
     assert rootlogger.level == logging.INFO  # per logging.yaml
 
 
-# Bad logging_levelname produces a warning message.
-def test_bad_logging_levelname(monkeypatch):
+# Bad logging_level produces a warning message.
+def test_bad_logging_level(monkeypatch):
     # Arrange
     rootlogger_reset()
     assert rootlogger.level == logging.DEBUG
@@ -46,14 +45,13 @@ def test_bad_logging_levelname(monkeypatch):
         'logging_configfiles': 
             [Path(mylogging.__file__).parent.joinpath('logging.yaml')],
         'logging_configfile': None,
-        'logging_levelname': 'WALNUT',  # bad value
+        'logging_level': 'WALNUT',  # bad value
         }
     monkeypatch.setattr(mylogging.config, 'get_config', lambda: _config)
     logging.debug('%s: %r', '_config', _config)
 
     # Act
-    logrecords = []
-    mylogging.configure(logrecords)
+    mylogging.configure()
 
     # Assert
     # WARNING Trouble overriding root logger level.
@@ -68,7 +66,7 @@ def test_bad_specific_logging_configfile(monkeypatch):
     _config = {
         'logging_configfiles': [],
         'logging_configfile': Path('/bravo/charlie.yaml'),
-        # 'logging_levelname': None,
+        # 'logging_level': None,
         }
     monkeypatch.setattr(mylogging.config, 'get_config', lambda: _config)
     logging.debug('%s: %r', '_config', _config)


### PR DESCRIPTION
This is a bug fix for a minor issue.
Two DEBUG level log messages are output at LabGym start, despite a logging_level setting of INFO (which is the default).  That's because they come from config.py which was naive re the special handling to defer log record handling until after the configuring of the logging system has been completed.  Oops.
This PR reworks and simplifies the deferral of the early log record handling, and config.py may remain naive.
The result is that with this fix, and assuming logging_level is INFO (the default),
the first two DEBUG messages (the first 9 lines below) are suppressed.  Which is the correct behavior.
```
% LabGym             
DEBUG:LabGym.config:/Users/john/.labgym/config.toml: file not found
DEBUG:LabGym.config:result:
{'anonymous': False,
 'configdir': PosixPath('/Users/john/.labgym'),
 'configfile': PosixPath('/Users/john/.labgym/config.toml'),
 'enable': {'central_logger': True, 'registration': True},
 'logging_configfiles': [PosixPath('/Users/john/.labgym/logging.toml'),
                         PosixPath('/Users/john/.labgym/logging.yaml'),
                         PosixPath('/Users/john/Public/LabGym/LabGym/logging.yaml')]}
2025-08-06 15:27:51.412524: I tensorflow/core/platform/cpu_feature_guard.cc:182] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.
To enable the following instructions: AVX2 FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.
2025-08-06 15:27:56	WARNING	[4511876608:py.warnings:warnings:109]	/Users/john/Public/LabGym/LabGym/detectron2/model_zoo/model_zoo.py:4: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources

2025-08-06 15:27:58	INFO	[4511876608:LabGym.probes:probes:65]	Central Logging is enabled.
2025-08-06 15:27:58	INFO	[4511876608:Central Logger:probes:123]	{'schema': 'context 2025-07-10', 'node': 'Johns-Air-3', 'platform': 'macOS-12.7.6-x86_64-i386-64bit', 'python_version': '3.10.11', 'version': '2.9.2', 'username': 'john', 'reginfo_uuid': 'a946b051-db70-4822-86e2-de8ae3e91d4a'}
2025-08-06 15:27:58	INFO	[4511876608:LabGym.gui_main:gui_main:343]	The user interface initialized!
```
