### PR TITLE
docs: update Linux, Windows, and MacOS installation

### DIFF
--- a/docs/installation/linux.md
+++ b/docs/installation/linux.md
@@ -6,9 +6,6 @@ Depending on which distribution of Linux you use, the process of installing pack
 If you're using Arch Linux or one of its derivatives, we assume you have the `yay` package manager installed to install dependencies from the AUR.
 ```
 
-```{tip}
-After running and completing a command, you can type `clear` in your terminal and hit Enter to tidy up the screen. It just clears your view—nothing is removed.
-```
 
 1. Update your system's package manager (either 'apt' for Debian-based Linux or 'pacman' for Arch Linux variants), then install `gcc`, `git`, and Python 3.10.
 

--- a/docs/installation/linux.md
+++ b/docs/installation/linux.md
@@ -6,8 +6,13 @@ Depending on which distribution of Linux you use, the process of installing pack
 If you're using Arch Linux or one of its derivatives, we assume you have the `yay` package manager installed to install dependencies from the AUR.
 ```
 
-1. Update your system's package manager, then install `gcc`, `git`, and Python 3.10.
+```{tip}
+After running and completing a command, you can type `clear` in your terminal and hit Enter to tidy up the screen. It just clears your view—nothing is removed.
+```
 
+1. Update your system's package manager (either 'apt' for Debian-based Linux or 'pacman' for Arch Linux variants), then install `gcc`, `git`, and Python 3.10.
+
+   Debian-based (e.g. Ubuntu):
    ```console
    sudo apt update
    ```
@@ -15,6 +20,7 @@ If you're using Arch Linux or one of its derivatives, we assume you have the `ya
    sudo apt install build-essential git python3.10
    ```
 
+   Arch-based (e.g. Arch Linux, Manjaro, etc):
    ```console
    sudo pacman -Syu
    ```
@@ -46,7 +52,11 @@ If you're using Arch Linux or one of its derivatives, we assume you have the `ya
    ```
 
 
-3. Upgrade `pip`, `wheel`, `setuptools`.
+3. Install `pip` if not already installed, and upgrade `pip`, `wheel`, `setuptools`.
+
+   ```console
+   sudo apt install python3-pip
+   ```
 
    ```console
    python3 -m pip install --upgrade pip wheel setuptools
@@ -55,7 +65,7 @@ If you're using Arch Linux or one of its derivatives, we assume you have the `ya
 4. Install wxPython
 
    ```console
-   apt-get install libgtk-3-dev
+   sudo apt-get install libgtk-3-dev
    ```
    ```console
    sudo apt-get install git curl libsdl2-mixer-2.0-0 libsdl2-image-2.0-0 libsdl2-2.0-0
@@ -66,6 +76,10 @@ If you're using Arch Linux or one of its derivatives, we assume you have the `ya
 
 5. Install LabGym via `pip`.
  
+   ```console
+   pip install --upgrade setuptools packaging
+   ```
+
    ```console
    python3 -m pip install LabGym
    ```

--- a/docs/installation/macos.md
+++ b/docs/installation/macos.md
@@ -2,6 +2,10 @@
 
 To access the terminal on macOS, use `Cmd+Space` to enter Spotlight Search, then search for "Terminal" and hit enter to open it. Next, follow these steps to install LabGym.
 
+```{tip}
+After running and completing a command, you can type `clear` in your terminal and hit Enter to tidy up the screen. It just clears your view—nothing is removed.
+```
+
 1. Install [Python 3.10](https://www.python.org/downloads/release/python-31011/). Scroll down to the bottom and click the `macOS 64-bit universal2 installer` option. Run the installer and select "Add python to path".
 
 2. Upgrade `pip`, `wheel`, `setuptools`.

--- a/docs/installation/macos.md
+++ b/docs/installation/macos.md
@@ -2,9 +2,6 @@
 
 To access the terminal on macOS, use `Cmd+Space` to enter Spotlight Search, then search for "Terminal" and hit enter to open it. Next, follow these steps to install LabGym.
 
-```{tip}
-After running and completing a command, you can type `clear` in your terminal and hit Enter to tidy up the screen. It just clears your view—nothing is removed.
-```
 
 1. Install [Python 3.10](https://www.python.org/downloads/release/python-31011/). Scroll down to the bottom and click the `macOS 64-bit universal2 installer` option. Run the installer and select "Add python to path".
 

--- a/docs/installation/windows.md
+++ b/docs/installation/windows.md
@@ -2,9 +2,6 @@
 
 To install LabGym on Windows, you will need to access the terminal. To do this, open the start menu by clicking the `Win` key, type "PowerShell", and hit enter. All terminal commands going forward should be entered in this terminal.
 
-```{tip}
-After running and completing a command, you can type `clear` in your terminal and hit Enter to tidy up the screen. It just clears your view—nothing is removed.
-```
 
 1. Install [Python 3.10](https://www.python.org/downloads/release/python-31011/).
    
@@ -19,19 +16,9 @@ After running and completing a command, you can type `clear` in your terminal an
 2. If you're using an NVIDIA GPU, install CUDA Toolkit 11.8 and cuDNN, and install PyTorch v2.0.1 with cu118 support.
 
    First, install and/or update your GPU drivers at [this link](https://www.nvidia.com/Download/index.aspx). 
-   
-   To view the name of your system's NVIDIA GPU, use the following command.
-
-   ```pwsh-session
-   wmic path win32_VideoController get name
-   ```
 
    Select your GPU model and click "Search", then click "Download". After installing the drivers, reboot your system to ensure they take effect.
    To verify that your system is utilizing the proper driver version, use the following command.
-
-   ```pwsh-session
-   nvidia-smi
-   ```
 
    Then, install [CUDA Toolkit 11.8](https://developer.nvidia.com/cuda-11-8-0-download-archive?target_os=Windows&target_arch=x86_64). Select your version of Windows, select "exe (local)," then click "Download."
 
@@ -46,12 +33,6 @@ After running and completing a command, you can type `clear` in your terminal an
 
    Next, install [cuDNN](https://developer.nvidia.com/rdp/cudnn-archive). You will need to register an NVIDIA Developer account, which you can do for free. You can choose cuDNN v8.9.7 that supports CUDA toolkit v11.8. Choose 'Local Installer for Windows (Zip)', download and extract it. And then copy the three folders 'bin', 'lib', and 'include' into where the CUDA toolkit is installed (typcially, 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8\'), and replace all the three folders with the same names. After that, you may need to add the 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8' to the 'PATH' environmental variable.
 
-
-   If you'd like to verify the installation of cuDNN, use the following command (expect long runtime if your file directory is considerably large).
-
-   ```pwsh-session
-   Get-ChildItem -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA" -Recurse -Filter "cudnn*.dll" -ErrorAction SilentlyContinue
-   ```
 
    Finally, install PyTorch v2.0.1 with cu118 support.
 

--- a/docs/installation/windows.md
+++ b/docs/installation/windows.md
@@ -2,6 +2,10 @@
 
 To install LabGym on Windows, you will need to access the terminal. To do this, open the start menu by clicking the `Win` key, type "PowerShell", and hit enter. All terminal commands going forward should be entered in this terminal.
 
+```{tip}
+After running and completing a command, you can type `clear` in your terminal and hit Enter to tidy up the screen. It just clears your view—nothing is removed.
+```
+
 1. Install [Python 3.10](https://www.python.org/downloads/release/python-31011/).
    
    Scroll down to the bottom and click the `Windows installer (64-bit)` option. Run the installer and select "Add python to path" and "Disable long path limit".
@@ -14,7 +18,20 @@ To install LabGym on Windows, you will need to access the terminal. To do this, 
 
 2. If you're using an NVIDIA GPU, install CUDA Toolkit 11.8 and cuDNN, and install PyTorch v2.0.1 with cu118 support.
 
-   First, install and/or update your GPU drivers at [this link](https://www.nvidia.com/Download/index.aspx). Select your GPU model and click "Search", then click "Download". After installing the drivers, reboot your system to ensure they take effect.
+   First, install and/or update your GPU drivers at [this link](https://www.nvidia.com/Download/index.aspx). 
+   
+   To view the name of your system's NVIDIA GPU, use the following command.
+
+   ```pwsh-session
+   wmic path win32_VideoController get name
+   ```
+
+   Select your GPU model and click "Search", then click "Download". After installing the drivers, reboot your system to ensure they take effect.
+   To verify that your system is utilizing the proper driver version, use the following command.
+
+   ```pwsh-session
+   nvidia-smi
+   ```
 
    Then, install [CUDA Toolkit 11.8](https://developer.nvidia.com/cuda-11-8-0-download-archive?target_os=Windows&target_arch=x86_64). Select your version of Windows, select "exe (local)," then click "Download."
 
@@ -28,6 +45,13 @@ To install LabGym on Windows, you will need to access the terminal. To do this, 
    ```
 
    Next, install [cuDNN](https://developer.nvidia.com/rdp/cudnn-archive). You will need to register an NVIDIA Developer account, which you can do for free. You can choose cuDNN v8.9.7 that supports CUDA toolkit v11.8. Choose 'Local Installer for Windows (Zip)', download and extract it. And then copy the three folders 'bin', 'lib', and 'include' into where the CUDA toolkit is installed (typcially, 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8\'), and replace all the three folders with the same names. After that, you may need to add the 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8' to the 'PATH' environmental variable.
+
+
+   If you'd like to verify the installation of cuDNN, use the following command (expect long runtime if your file directory is considerably large).
+
+   ```pwsh-session
+   Get-ChildItem -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA" -Recurse -Filter "cudnn*.dll" -ErrorAction SilentlyContinue
+   ```
 
    Finally, install PyTorch v2.0.1 with cu118 support.
 


### PR DESCRIPTION
In anticipation of the LabGym tutorial presentation, made minor corrections and helpful additions to installation guide docs (mostly Linux and Windows guides). Linux installation directives were based off of a recent install of LabGym on Ubuntu Desktop 22.04 (fairly common distro). Feel free to let me know if you have any questions!