### PR TITLE
removed 4 info from the context data.

### DIFF
--- a/LabGym/probes.py
+++ b/LabGym/probes.py
@@ -169,27 +169,27 @@ def get_context(anonymous: bool=False) -> dict:
         reginfo_uuid = None
 
     result = {
-        'schema': 'context 2025-07-10',
+        'schema': 'context 2025-08-10',
 
         # computer name & os, and python version
-        'node': platform.node(),  # the computer's network name
-        'platform': platform.platform(aliased=True),
+        # 'node': platform.node(),  # the computer's network name
+        # 'platform': platform.platform(aliased=True),
         'python_version': platform.python_version(),
 
         # LabGym sw
         'version': version,  # LabGym version
 
         # User info
-        'username': getpass.getuser(),
-        'reginfo_uuid': reginfo_uuid,
+        # 'username': getpass.getuser(),
+        # 'reginfo_uuid': reginfo_uuid,
         }
 
-    # If anonymous-flag is True, then anonymize the context data.
-    if anonymous:
-        result.update({
-            'node': 'anonymous',
-            'username': 'anonymous',
-            'reginfo_uuid': 'anonymous',
-            })
+    # # If anonymous-flag is True, then anonymize the context data.
+    # if anonymous:
+    #     result.update({
+    #         'node': 'anonymous',
+    #         'username': 'anonymous',
+    #         'reginfo_uuid': 'anonymous',
+    #         })
 
     return result


### PR DESCRIPTION
Remove 4 fields from the "context" info sent during LabGym start to the Central Receiver.
Now the context info looks like this:
`2025-08-10 11:20:53	INFO	[4682057216:Central Logger:probes:126]	{'schema': 'context 2025-08-10', 'python_version': '3.10.11', 'version': '2.9.3'}`
