### PR TITLE
Fix pyobjc error on Linux

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies=[
     'black',
     'ninja',
     'six',
-    'pyobjc-framework-Cocoa;platform_system!="Windows"',
+    'pyobjc-framework-Cocoa;platform_system=="Darwin"',
 ]
 requires-python='>=3.9,<3.11'
 readme='README.md'


### PR DESCRIPTION
Prevent `pyobjc-framework-Cocoa` from installing on Linux.

Changed platform marker in `pyproject.toml` to:
    `pyobjc-framework-Cocoa; platform_system == "Darwin"`

Fixes install errors on all non-macOS systems (not just Windows).