### PR TITLE
Pylint positive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,6 @@ LabGym/models/
 !LabGym/models/__init__.py
 LabGym/detectors/
 !LabGym/detectors/__init__.py
+
+# test tmpdirs
+tmp.pylint

--- a/LabGym/__init__.py
+++ b/LabGym/__init__.py
@@ -1,3 +1,5 @@
+# suppress '__init__.py:1:0: C0103: Module name "LabGym" doesn't conform to snake_case naming style (invalid-name)'
+# pylint: disable=invalid-name
 '''
 Copyright (C)
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -20,6 +22,3 @@ Email: bingye@umich.edu
 
 
 __version__='2.9.6'
-
-
-

--- a/LabGym/__init__.py
+++ b/LabGym/__init__.py
@@ -19,6 +19,4 @@ Email: bingye@umich.edu
 '''
 
 
-
-
 __version__='2.9.6'

--- a/LabGym/__main__.py
+++ b/LabGym/__main__.py
@@ -3,7 +3,7 @@
 Copyright (C)
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-You should have received a copy of the GNU General Public License along with this program. If not, see https://tldrlegal.com/license/gnu-general-public-license-v3-(gpl-3)#fulltext. 
+You should have received a copy of the GNU General Public License along with this program. If not, see https://tldrlegal.com/license/gnu-general-public-license-v3-(gpl-3)#fulltext.
 
 For license issues, please contact:
 

--- a/LabGym/__main__.py
+++ b/LabGym/__main__.py
@@ -91,5 +91,3 @@ def main() -> None:
 if __name__=='__main__':  # pragma: no cover
 
 	main()
-
-

--- a/LabGym/__main__.py
+++ b/LabGym/__main__.py
@@ -22,14 +22,13 @@ Email: bingye@umich.edu
 import logging
 from pathlib import Path
 
-
 # block begin
 # These statements are intentionally positioned before this module's
 # other imports (against the guidance of PEP 8), to log the loading of
 # this module before other import statements are executed and
 # potentially produce their own log messages.
-
-from LabGym import mylogging
+# pylint: disable=wrong-import-position
+from LabGym import mylogging  # pylint: disable=ungrouped-imports
 # Collect logrecords and defer handling until logging is configured.
 mylogging.defer()
 
@@ -39,16 +38,17 @@ logger.debug('loading %s', __file__)
 
 # Configure logging based on configfile, then handle collected logrecords.
 mylogging.configure()
+# pylint: enable=wrong-import-position
 # block end
 
-
 # Related third party imports.
-import requests  # Python HTTP for Humans.
 from packaging import version  # Core utilities for Python packages
+import requests  # Python HTTP for Humans.
 
 # Local application/library specific imports.
-from LabGym import mypkg_resources  # replace deprecated pkg_resources
 from LabGym import __version__, gui_main, probes
+# pylint: disable-next=unused-import
+from LabGym import mypkg_resources  # replace deprecated pkg_resources
 
 
 logger.debug('%s: %r', '(__name__, __package__)', (__name__, __package__))

--- a/LabGym/analyzebehavior.py
+++ b/LabGym/analyzebehavior.py
@@ -1381,5 +1381,3 @@ class AnalyzeAnimal():
 		capture.release()
 
 		print('Behavior example generation completed!')
-
-

--- a/LabGym/analyzebehavior.py
+++ b/LabGym/analyzebehavior.py
@@ -2,7 +2,7 @@
 Copyright (C)
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-You should have received a copy of the GNU General Public License along with this program. If not, see https://tldrlegal.com/license/gnu-general-public-license-v3-(gpl-3)#fulltext. 
+You should have received a copy of the GNU General Public License along with this program. If not, see https://tldrlegal.com/license/gnu-general-public-license-v3-(gpl-3)#fulltext.
 
 For license issues, please contact:
 
@@ -92,7 +92,7 @@ class AnalyzeAnimal():
 		self.event_probability={}
 		self.all_behavior_parameters={}
 		self.log=[]
-		
+
 
 	def prepare_analysis(self,
 		path_to_video, # path to the video for generating behavior examples or behavior analysis
@@ -118,7 +118,7 @@ class AnalyzeAnimal():
 		length=15, # the duration (number of frames) of a behavior example (a behavior episode)
 		animal_vs_bg=0 # 0: animals brighter than the background; 1: animals darker than the background; 2: hard to tell
 		):
-		
+
 		print('Preparation started...')
 		self.log.append('Preparation started...')
 		print(datetime.datetime.now())
@@ -270,7 +270,7 @@ class AnalyzeAnimal():
 		if len(unused_existing_indices)>0:
 			for i in unused_existing_indices:
 				if self.to_deregister[i]<=self.count_to_deregister:
-					self.to_deregister[i]+=1		
+					self.to_deregister[i]+=1
 				else:
 					self.animal_existingcenters[i]=(-10000,-10000)
 				if self.include_bodyparts:
@@ -320,7 +320,7 @@ class AnalyzeAnimal():
 			if time>=start_t:
 
 				self.all_time.append(round((time-start_t),2))
-				
+
 				if (frame_count_analyze+1)%1000==0:
 					print(str(frame_count_analyze+1)+' frames processed...')
 					self.log.append(str(frame_count_analyze+1)+' frames processed...')
@@ -424,7 +424,7 @@ class AnalyzeAnimal():
 			if time>=start_t:
 
 				self.all_time.append(round((time-start_t),2))
-				
+
 				if (frame_count_analyze+1)%1000==0:
 					print(str(frame_count_analyze+1)+' frames processed...')
 					self.log.append(str(frame_count_analyze+1)+' frames processed...')
@@ -613,7 +613,7 @@ class AnalyzeAnimal():
 									self.event_probability[n][i]=[behavior_names[1],prediction[0]]
 							if prediction[0]<0.5:
 								if (1-prediction[0])-prediction[0]>uncertain:
-									self.event_probability[n][i]=[behavior_names[0],1-prediction[0]]		
+									self.event_probability[n][i]=[behavior_names[0],1-prediction[0]]
 						else:
 							if sorted(prediction)[-1]-sorted(prediction)[-2]>uncertain:
 								self.event_probability[n][i]=[behavior_names[np.argmax(prediction)],max(prediction)]
@@ -665,13 +665,13 @@ class AnalyzeAnimal():
 					hex_color=self.all_behavior_parameters[behavior_name]['color'][1].lstrip('#')
 					color=tuple(int(hex_color[i:i+2],16) for i in (0,2,4))
 					colors[behavior_name]=color[::-1]
-			
+
 			if len(behavior_to_include)!=len(self.all_behavior_parameters):
 				for behavior_name in self.all_behavior_parameters:
 					if behavior_name not in behavior_to_include:
 						del colors[behavior_name]
-			
-			if show_legend:	
+
+			if show_legend:
 				scl=self.background.shape[0]/1024
 				if 25*(len(colors)+1)<self.background.shape[0]:
 					intvl=25
@@ -817,7 +817,7 @@ class AnalyzeAnimal():
 						self.all_behavior_parameters[behavior_name]['distance'][i]=0.0
 					if 'latency' in parameter_to_analyze:
 						self.all_behavior_parameters[behavior_name]['latency'][i]='NA'
-			
+
 				for parameter_name in all_parameters:
 					for i in self.event_probability:
 						self.all_behavior_parameters[behavior_name][parameter_name][i]=[np.nan]*len(self.all_time)
@@ -829,7 +829,7 @@ class AnalyzeAnimal():
 					self.all_behavior_parameters['distance'][i]=0.0
 				for parameter_name in all_parameters:
 					self.all_behavior_parameters[parameter_name][i]=[np.nan]*len(self.all_time)
-				
+
 		if len(parameter_to_analyze)>0:
 
 			for i in self.animal_contours:
@@ -847,7 +847,7 @@ class AnalyzeAnimal():
 							if 'count' in parameter_to_analyze:
 								if behavior_name!=self.event_probability[i][n-1][0]:
 									self.all_behavior_parameters[behavior_name]['count'][i]+=1
-									
+
 							if 'duration' in parameter_to_analyze:
 								self.all_behavior_parameters[behavior_name]['duration'][i]+=1
 
@@ -861,7 +861,7 @@ class AnalyzeAnimal():
 									if h is None or self.animal_heights[i][n] is None:
 										height_diff=0.0
 									else:
-										height_diff=abs(h-self.animal_heights[i][n])/h	
+										height_diff=abs(h-self.animal_heights[i][n])/h
 									heights_diffs.append(height_diff)
 								magnitude_length=max(heights_diffs)
 								vigor_length=magnitude_length/((self.length-np.argmax(heights_diffs))/self.fps)
@@ -896,7 +896,7 @@ class AnalyzeAnimal():
 										if ct is None:
 											displacements.append(0)
 										else:
-											displacements.append(math.dist(end_center,ct))		
+											displacements.append(math.dist(end_center,ct))
 									displacement=max(displacements)
 									if normalize_distance:
 										displacement=displacement/calibrator
@@ -1077,7 +1077,7 @@ class AnalyzeAnimal():
 					n+=1
 
 				if self.categorize_behavior:
-				
+
 					if 'duration' in parameter_to_analyze:
 						for behavior_name in self.all_behavior_parameters:
 							if self.all_behavior_parameters[behavior_name]['duration'][i]!=0:
@@ -1119,7 +1119,7 @@ class AnalyzeAnimal():
 
 		if self.categorize_behavior:
 			all_parameters.append('probability')
-			
+
 		if 'count' in parameter_to_analyze:
 			all_parameters.append('count')
 		if 'duration' in parameter_to_analyze:
@@ -1171,7 +1171,7 @@ class AnalyzeAnimal():
 					individual_df.to_excel(os.path.join(self.results_path,parameter_name+'.xlsx'),float_format='%.2f',index_label='time/ID')
 
 			if len(summary)>=1:
-				pd.concat(summary,axis=1).to_excel(os.path.join(self.results_path,'all_summary.xlsx'),float_format='%.2f',index_label='ID/parameter')			
+				pd.concat(summary,axis=1).to_excel(os.path.join(self.results_path,'all_summary.xlsx'),float_format='%.2f',index_label='ID/parameter')
 
 		print('All results exported in: '+str(self.results_path))
 		self.log.append('All results exported in: '+str(self.results_path))
@@ -1186,7 +1186,7 @@ class AnalyzeAnimal():
 		# background_free: whether to include background in animations
 		# black_background: whether to set background black
 		# skip_redundant: the interval (in frames) of two consecutively generated behavior example pairs
-		
+
 		print('Generating behavior examples...')
 		print(datetime.datetime.now())
 
@@ -1303,7 +1303,7 @@ class AnalyzeAnimal():
 		temp_inners=deque(maxlen=self.length)
 		animation=deque(maxlen=self.length)
 		os.makedirs(os.path.join(self.results_path,'examples','0'),exist_ok=True)
-		
+
 		start_t=round((self.t-self.length/self.fps),2)
 		if start_t<0:
 			start_t=0.00
@@ -1366,7 +1366,7 @@ class AnalyzeAnimal():
 
 							path_animation=os.path.join(self.results_path,'examples','0',animation_name)
 							path_pattern_image=os.path.join(self.results_path,'examples','0',pattern_image_name)
-						
+
 							writer=cv2.VideoWriter(path_animation,cv2.VideoWriter_fourcc(*'MJPG'),self.fps/5,(w,h),True)
 							for blob in animation:
 								writer.write(cv2.resize(blob,(w,h),interpolation=cv2.INTER_AREA))

--- a/LabGym/analyzebehavior.py
+++ b/LabGym/analyzebehavior.py
@@ -16,34 +16,56 @@ USA
 Email: bingye@umich.edu
 '''
 
+# Standard library imports.
+from collections import deque
+import datetime
+import functools
+import gc
+import logging
+import math
+import operator
+import os
+
 # Log the load of this module (by the module loader, on first import).
 # Intentionally positioning these statements before other imports, against the
 # guidance of PEP-8, to log the load before other imports log messages.
-import logging
-logger =  logging.getLogger(__name__)
-logger.debug('loading %s', __file__)
+logger =  logging.getLogger(__name__)  # pylint: disable=wrong-import-position
+logger.debug('loading %s', __file__)  # pylint: disable=wrong-import-position
 
-
-
-logger.debug('importing tools (starting...)')
-from .tools import *
-logger.debug('importing tools (done)')
-import os
-import gc
+# Related third party imports.
 import cv2
-import datetime
 import numpy as np
-import math
-from scipy.spatial import distance
-from collections import deque
-import tensorflow as tf
-from tensorflow.keras.models import load_model
-from tensorflow.keras.preprocessing.image import img_to_array
 import pandas as pd
-import seaborn as sb
-import functools
-import operator
+from scipy.spatial import distance
+# import seaborn as sb
+import tensorflow as tf
+# from tensorflow.keras.models import load_model
+# from tensorflow.keras.preprocessing.image import img_to_array
+from tensorflow import keras  # pylint: disable=unused-import
+from keras.models import load_model
+from keras.preprocessing.image import img_to_array
 
+# Local application/library specific imports.
+logger.debug('importing tools (starting...)')
+from .tools import (
+    # extract_background,
+    estimate_constants,
+    crop_frame,
+    extract_blob_background,
+    extract_blob_all,
+    # get_inner,
+    contour_frame,
+    generate_patternimage,
+    generate_patternimage_all,
+    # generate_patternimage_interact,
+    # plot_events,
+    # extract_frames,
+    # preprocess_video,
+    # parse_all_events_file,
+    # calculate_distances,
+    # sort_examples_from_csv,
+    )
+logger.debug('importing tools (done)')
 
 
 class AnalyzeAnimal():

--- a/LabGym/analyzebehavior_dt.py
+++ b/LabGym/analyzebehavior_dt.py
@@ -16,29 +16,50 @@ USA
 Email: bingye@umich.edu
 '''
 
-
-
-
-from .tools import *
-from .detector import Detector
-import os
-import gc
-import cv2
-import torch
-import datetime
-import numpy as np
-import math
-from scipy.spatial import distance
+# Standard library imports.
 from collections import deque
-import tensorflow as tf
-from tensorflow.keras.models import load_model
-from tensorflow.keras.preprocessing.image import img_to_array
-import pandas as pd
-import seaborn as sb
-from skimage import exposure
+import datetime
 import functools
+import gc
+import math
 import operator
+import os
 
+# Related third party imports.
+import cv2
+import numpy as np
+import pandas as pd
+from scipy.spatial import distance
+# import seaborn as sb
+from skimage import exposure
+import tensorflow as tf
+# from tensorflow.keras.models import load_model
+# from tensorflow.keras.preprocessing.image import img_to_array
+from tensorflow import keras  # pylint: disable=unused-import
+from keras.models import load_model
+from keras.preprocessing.image import img_to_array
+import torch
+
+# Local application/library specific imports.
+from .detector import Detector
+from .tools import (
+    # extract_background,
+    # estimate_constants,
+    crop_frame,
+    extract_blob_background,
+    extract_blob_all,
+    get_inner,
+    # contour_frame,
+    generate_patternimage,
+    generate_patternimage_all,
+    generate_patternimage_interact,
+    # plot_events,
+    # extract_frames,
+    # preprocess_video,
+    # parse_all_events_file,
+    # calculate_distances,
+    # sort_examples_from_csv,
+    )
 
 
 class AnalyzeAnimalDetector():

--- a/LabGym/analyzebehavior_dt.py
+++ b/LabGym/analyzebehavior_dt.py
@@ -2429,5 +2429,3 @@ class AnalyzeAnimalDetector():
 					results_df.set_index(names).join(pd.DataFrame.from_dict(animal_information[behavior_name][animal_name]['probability'],orient='index',columns=['probability']).reset_index(drop=True).set_index(names)).to_excel(os.path.join(results_path,behavior_name+'_'+animal_name+'.xlsx'),index_label='imagename/parameter')
 
 			print('All results exported in: '+str(results_path))
-
-

--- a/LabGym/analyzebehavior_dt.py
+++ b/LabGym/analyzebehavior_dt.py
@@ -2,7 +2,7 @@
 Copyright (C)
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-You should have received a copy of the GNU General Public License along with this program. If not, see https://tldrlegal.com/license/gnu-general-public-license-v3-(gpl-3)#fulltext. 
+You should have received a copy of the GNU General Public License along with this program. If not, see https://tldrlegal.com/license/gnu-general-public-license-v3-(gpl-3)#fulltext.
 
 For license issues, please contact:
 
@@ -114,7 +114,7 @@ class AnalyzeAnimalDetector():
 		length=15, # the duration (number of frames) of a behavior example (a behavior episode)
 		social_distance=0 # the distance to determine which two animals / objects form a interactive pair / group
 		):
-		
+
 		print('Preparation started...')
 		self.log.append('Preparation started...')
 		print(datetime.datetime.now())
@@ -460,7 +460,7 @@ class AnalyzeAnimalDetector():
 								mask=goodmasks[x]
 								cnt=goodcontours[x]
 								contours.append(cnt)
-								centers.append((int(cv2.moments(cnt)['m10']/cv2.moments(cnt)['m00']),int(cv2.moments(cnt)['m01']/cv2.moments(cnt)['m00'])))  
+								centers.append((int(cv2.moments(cnt)['m10']/cv2.moments(cnt)['m00']),int(cv2.moments(cnt)['m01']/cv2.moments(cnt)['m00'])))
 								(_,_),(w,h),_=cv2.minAreaRect(cnt)
 								heights.append(max(w,h))
 								if self.include_bodyparts:
@@ -468,7 +468,7 @@ class AnalyzeAnimalDetector():
 									inners.append(get_inner(masked_frame,cnt))
 
 							self.track_animal(frame_count_analyze+1-batch_size+batch_count,animal_name,contours,centers,heights,inners=inners)
-							
+
 							if self.animation_analyzer:
 								for i in self.animal_centers[animal_name]:
 									for n,f in enumerate(self.temp_frames):
@@ -589,7 +589,7 @@ class AnalyzeAnimalDetector():
 								all_masks.append(mask)
 								cnt=goodcontours[x]
 								all_contours.append(cnt)
-								all_centers.append((int(cv2.moments(cnt)['m10']/cv2.moments(cnt)['m00']),int(cv2.moments(cnt)['m01']/cv2.moments(cnt)['m00'])))  
+								all_centers.append((int(cv2.moments(cnt)['m10']/cv2.moments(cnt)['m00']),int(cv2.moments(cnt)['m01']/cv2.moments(cnt)['m00'])))
 								(_,_),(w,h),_=cv2.minAreaRect(cnt)
 								all_heights.append(max(w,h))
 								if self.include_bodyparts:
@@ -702,7 +702,7 @@ class AnalyzeAnimalDetector():
 			if time>=start_t:
 
 				self.all_time.append(round((time-start_t),2))
-				
+
 				if (frame_count_analyze+1)%1000==0:
 					print(str(frame_count_analyze+1)+' frames processed...')
 					self.log.append(str(frame_count_analyze+1)+' frames processed...')
@@ -791,7 +791,7 @@ class AnalyzeAnimalDetector():
 			if time>=start_t:
 
 				self.all_time.append(round((time-start_t),2))
-				
+
 				if (frame_count_analyze+1)%1000==0:
 					print(str(frame_count_analyze+1)+' frames processed...')
 					self.log.append(str(frame_count_analyze+1)+' frames processed...')
@@ -891,7 +891,7 @@ class AnalyzeAnimalDetector():
 										blob=cv2.resize(blob,(self.dim_tconv,self.dim_tconv),interpolation=cv2.INTER_AREA)
 									animation.append(img_to_array(blob))
 									self.animations[name][0][frame_count_analyze+1-batch_size+batch_count]=np.array(animation)
-					
+
 					batch=[]
 					batch_count=0
 
@@ -906,7 +906,7 @@ class AnalyzeAnimalDetector():
 		self.pattern_images[name][0]=self.pattern_images[name][0][:length]
 		self.animal_contours[name][0]=self.animal_contours[name][0][:length]
 		self.animal_centers[name][0]=self.animal_centers[name][0][:length]
-		
+
 		print('Information acquisition completed!')
 		self.log.append('Information acquisition completed!')
 
@@ -936,7 +936,7 @@ class AnalyzeAnimalDetector():
 
 			if len(IDs)==len(to_delete):
 				to_delete.remove(np.argsort(lengths)[-1])
-			
+
 			for i in IDs:
 				if i in to_delete:
 					del self.to_deregister[animal_name][i]
@@ -1154,13 +1154,13 @@ class AnalyzeAnimalDetector():
 					hex_color=self.all_behavior_parameters[self.animal_kinds[0]][behavior_name]['color'][1].lstrip('#')
 					color=tuple(int(hex_color[i:i+2],16) for i in (0,2,4))
 					colors[behavior_name]=color[::-1]
-			
+
 			if len(behavior_to_include)!=len(self.all_behavior_parameters[self.animal_kinds[0]]):
 				for behavior_name in self.all_behavior_parameters[self.animal_kinds[0]]:
 					if behavior_name not in behavior_to_include:
 						del colors[behavior_name]
-			
-			if show_legend:	
+
+			if show_legend:
 				scl=self.background.shape[0]/1024
 				if 25*(len(colors)+1)<self.background.shape[0]:
 					intvl=25
@@ -1243,7 +1243,7 @@ class AnalyzeAnimalDetector():
 
 									if self.categorize_behavior:
 										if self.behavior_mode!=1:
-											cv2.putText(frame,str(animal_name)+' '+str(i),(cx-10,cy-25),cv2.FONT_HERSHEY_SIMPLEX,text_scl,animal_color,text_tk)	
+											cv2.putText(frame,str(animal_name)+' '+str(i),(cx-10,cy-25),cv2.FONT_HERSHEY_SIMPLEX,text_scl,animal_color,text_tk)
 										if self.event_probability[animal_name][i][frame_count_analyze][0]=='NA':
 											if self.behavior_mode==1:
 												cv2.drawContours(frame,self.animal_contours[animal_name][i][frame_count_analyze],-1,(255,255,255),1)
@@ -1327,7 +1327,7 @@ class AnalyzeAnimalDetector():
 						self.all_behavior_parameters[animal_name]['distance'][i]=0.0
 					for parameter_name in all_parameters:
 						self.all_behavior_parameters[animal_name][parameter_name][i]=[np.nan]*len(self.all_time)
-				
+
 		if len(parameter_to_analyze)>0:
 
 			for animal_name in self.animal_kinds:
@@ -1347,7 +1347,7 @@ class AnalyzeAnimalDetector():
 								if 'count' in parameter_to_analyze:
 									if behavior_name!=self.event_probability[animal_name][i][n-1][0]:
 										self.all_behavior_parameters[animal_name][behavior_name]['count'][i]+=1
-										
+
 								if 'duration' in parameter_to_analyze:
 									self.all_behavior_parameters[animal_name][behavior_name]['duration'][i]+=1
 
@@ -1361,7 +1361,7 @@ class AnalyzeAnimalDetector():
 										if h is None or self.animal_heights[animal_name][i][n] is None:
 											height_diff=0.0
 										else:
-											height_diff=abs(h-self.animal_heights[animal_name][i][n])/h	
+											height_diff=abs(h-self.animal_heights[animal_name][i][n])/h
 										heights_diffs.append(height_diff)
 									magnitude_length=max(heights_diffs)
 									vigor_length=magnitude_length/((self.length-np.argmax(heights_diffs))/self.fps)
@@ -1396,7 +1396,7 @@ class AnalyzeAnimalDetector():
 											if ct is None:
 												displacements.append(0)
 											else:
-												displacements.append(math.dist(end_center,ct))		
+												displacements.append(math.dist(end_center,ct))
 										displacement=max(displacements)
 										if normalize_distance:
 											displacement=displacement/calibrator
@@ -1576,7 +1576,7 @@ class AnalyzeAnimalDetector():
 						n+=1
 
 					if self.categorize_behavior:
-					
+
 						if 'duration' in parameter_to_analyze:
 							for behavior_name in self.all_behavior_parameters[animal_name]:
 								if self.all_behavior_parameters[animal_name][behavior_name]['duration'][i]!=0:
@@ -1620,7 +1620,7 @@ class AnalyzeAnimalDetector():
 
 			if self.categorize_behavior:
 				all_parameters.append('probability')
-				
+
 			if 'count' in parameter_to_analyze:
 				all_parameters.append('count')
 			if 'duration' in parameter_to_analyze:
@@ -1672,7 +1672,7 @@ class AnalyzeAnimalDetector():
 						individual_df.to_excel(os.path.join(self.results_path,animal_name+'_'+parameter_name+'.xlsx'),float_format='%.2f',index_label='time/ID')
 
 				if len(summary)>=1:
-					pd.concat(summary,axis=1).to_excel(os.path.join(self.results_path,animal_name+'_all_summary.xlsx'),float_format='%.2f',index_label='ID/parameter')			
+					pd.concat(summary,axis=1).to_excel(os.path.join(self.results_path,animal_name+'_all_summary.xlsx'),float_format='%.2f',index_label='ID/parameter')
 
 		print('All results exported in: '+str(self.results_path))
 		self.log.append('All results exported in: '+str(self.results_path))
@@ -1688,7 +1688,7 @@ class AnalyzeAnimalDetector():
 		# background_free: whether to include background in animations
 		# black_background: whether to set background black
 		# skip_redundant: the interval (in frames) of two consecutively generated behavior example pairs
-		
+
 		print('Generating behavior examples...')
 		print(datetime.datetime.now())
 
@@ -1723,7 +1723,7 @@ class AnalyzeAnimalDetector():
 				self.detect_track_individuals([frame],1,frame_count_analyze,background_free=background_free,black_background=black_background,animation=animation)
 
 				for animal_name in self.animal_kinds:
-						
+
 					if frame_count_analyze>=self.length and frame_count_analyze%skip_redundant==0:
 
 						for n in self.animal_centers[animal_name]:
@@ -2009,7 +2009,7 @@ class AnalyzeAnimalDetector():
 							exclusion_mask[np.where((np.sum(np.logical_and(np.array(animal_masks)[:,None],animal_masks),axis=(2,3))/mask_area[:,None]>0.8) & (mask_area[:,None]<mask_area[None,:]))[0]]=True
 							animal_masks=[m for m,exclude in zip(animal_masks,exclusion_mask) if not exclude]
 							animal_scores=[s for s,exclude in zip(animal_scores,exclusion_mask) if not exclude]
-							
+
 							if len(animal_masks)==0:
 								self.animal_present[animal_name]=0
 								for i in self.animal_centers[animal_name]:

--- a/LabGym/categorizer.py
+++ b/LabGym/categorizer.py
@@ -16,36 +16,73 @@ USA
 Email: bingye@umich.edu
 '''
 
-
-
-
-from .tools import *
-import matplotlib
-matplotlib.use('Agg')
-import os
-import cv2
-import datetime
-import numpy as np
-import matplotlib.pyplot as plt
-import random
+# Standard library imports.
 from collections import deque
+import datetime
+import itertools
+import os
+import random
+
+# Related third party imports.
+import cv2
+import matplotlib
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+# import scipy.ndimage as ndimage
+from scipy import ndimage
 from skimage import exposure,transform
 from skimage.transform import AffineTransform
-import scipy.ndimage as ndimage
-import tensorflow as tf
-from tensorflow.keras.preprocessing.image import img_to_array,load_img
-from tensorflow.keras.layers import Input,TimeDistributed,BatchNormalization,MaxPooling2D,Activation,ZeroPadding2D,Add
-from tensorflow.keras.layers import Conv2D,Dropout,Flatten,Dense,LSTM,concatenate,AveragePooling2D,GlobalMaxPooling2D
-from tensorflow.keras.models import Model,Sequential,load_model
-from tensorflow.keras.optimizers import SGD
-from tensorflow.keras.callbacks import ModelCheckpoint,EarlyStopping,ReduceLROnPlateau
-from tensorflow.keras.utils import plot_model,Sequence
-from sklearn.preprocessing import LabelBinarizer
-from sklearn.model_selection import train_test_split
 from sklearn.metrics import classification_report
-import pandas as pd
-import itertools
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import LabelBinarizer
+import tensorflow as tf
+# from tensorflow.keras.callbacks import ModelCheckpoint,EarlyStopping,ReduceLROnPlateau
+# from tensorflow.keras.layers import Input,TimeDistributed,BatchNormalization,MaxPooling2D,Activation,ZeroPadding2D,Add
+# from tensorflow.keras.layers import Conv2D,Dropout,Flatten,Dense,LSTM,concatenate,AveragePooling2D,GlobalMaxPooling2D
+# from tensorflow.keras.models import Model,Sequential,load_model
+# from tensorflow.keras.optimizers import SGD
+# from tensorflow.keras.preprocessing.image import img_to_array,load_img
+# from tensorflow.keras.utils import plot_model,Sequence
+from tensorflow import keras  # pylint: disable=unused-import
+from keras.callbacks import ModelCheckpoint,EarlyStopping,ReduceLROnPlateau
+from keras.layers import (
+    Activation,
+    Add,
+    AveragePooling2D,
+    BatchNormalization,
+    Conv2D,
+    Dense,
+    Dropout,
+    Flatten,
+    # GlobalMaxPooling2D,
+    Input,
+    LSTM,
+    MaxPooling2D,
+    TimeDistributed,
+    ZeroPadding2D,
+    concatenate,
+    )
+from keras.models import (
+    Model,
+    # Sequential,
+    load_model,
+    )
+from keras.optimizers import SGD
+from keras.preprocessing.image import (
+    img_to_array,
+    # load_img,
+    )
+from keras.utils import (
+    # plot_model,
+    Sequence,
+    )
 
+# Local application/library specific imports.
+# (none)
+
+
+matplotlib.use('Agg')
 
 
 class DatasetFromPath_AA(Sequence):

--- a/LabGym/categorizer.py
+++ b/LabGym/categorizer.py
@@ -2,7 +2,7 @@
 Copyright (C)
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-You should have received a copy of the GNU General Public License along with this program. If not, see https://tldrlegal.com/license/gnu-general-public-license-v3-(gpl-3)#fulltext. 
+You should have received a copy of the GNU General Public License along with this program. If not, see https://tldrlegal.com/license/gnu-general-public-license-v3-(gpl-3)#fulltext.
 
 For license issues, please contact:
 
@@ -235,7 +235,7 @@ class Categorizers():
 				if len(name_list)==0:
 					name_list=[i for i in os.listdir(os.path.join(file_path,folder)) if i.endswith('.jpg')]
 					imagedata=True
-			
+
 				for i in name_list:
 
 					if imagedata:
@@ -349,7 +349,7 @@ class Categorizers():
 			name=os.path.splitext(os.path.basename(i))[0].split('_')[0]
 			label=os.path.splitext(i)[0].split('_')[-1]
 			path_to_pattern_image=os.path.splitext(i)[0]+'.jpg'
-			
+
 			random.shuffle(methods)
 
 			for m in methods:
@@ -730,7 +730,7 @@ class Categorizers():
 		else:
 
 			x=Activation('relu')(x)
-		
+
 			x=Conv2D(int(filters*4),(1,1),strides=(1,1))(x)
 			x=BatchNormalization()(x)
 
@@ -779,7 +779,7 @@ class Categorizers():
 		else:
 
 			x=TimeDistributed(Activation('relu'))(x)
-		
+
 			x=TimeDistributed(Conv2D(int(filters*4),(1,1),strides=(1,1)))(x)
 			x=TimeDistributed(BatchNormalization())(x)
 
@@ -892,7 +892,7 @@ class Categorizers():
 			x=LSTM(2048,return_sequences=False,return_state=False)(x)
 		else:
 			x=LSTM(4096,return_sequences=False,return_state=False)(x)
-			
+
 		if with_classifier is False:
 
 			return x
@@ -905,7 +905,7 @@ class Categorizers():
 				x=Dense(2048,activation='relu')(x)
 			else:
 				x=Dense(4096,activation='relu')(x)
-				
+
 			x=Dropout(0.5)(x)
 			if classes==2:
 				x=Dense(1,activation='sigmoid')(x)
@@ -935,7 +935,7 @@ class Categorizers():
 
 		for i in range(round(dim_tconv/60)):
 			filters_tconv=min(int(filters_tconv*2),64)
-		
+
 		for i in range(round(dim_conv/60)):
 			filters_conv=min(int(filters_conv*2),64)
 
@@ -943,7 +943,7 @@ class Categorizers():
 			animation_feature=self.simple_tvgg(animation_inputs,filters_tconv,level=level_tconv,with_classifier=False)
 		else:
 			animation_feature=self.simple_tresnet(animation_inputs,filters_tconv,level=level_tconv,with_classifier=False)
-		
+
 		if level_conv<5:
 			pattern_image_feature=self.simple_vgg(pattern_image_inputs,filters_conv,level=level_conv,with_classifier=False)
 		else:
@@ -1122,7 +1122,7 @@ class Categorizers():
 				pd.DataFrame(report).transpose().to_csv(os.path.join(model_path,'training_metrics.csv'),float_format='%.2f')
 				if out_path is not None:
 					pd.DataFrame(report).transpose().to_excel(os.path.join(out_path,'training_metrics.xlsx'),float_format='%.2f')
-				
+
 				plt.style.use('classic')
 				plt.figure()
 				plt.plot(H.history['loss'],label='train_loss')
@@ -1192,7 +1192,7 @@ class Categorizers():
 
 		for i in range(round(dim/60)):
 			filters=min(int(filters*2),64)
-		
+
 		inputs=Input(shape=(time_step,dim,dim,channel))
 
 		print('Training the Categorizer w/o Pattern Recognizer using the behavior examples in: '+str(data_path))
@@ -1935,7 +1935,7 @@ class Categorizers():
 			else:
 				print('The type of the Categorizer: Pattern Recognizer (Lv '+str(level_conv)+'; Shape '+str(dim_conv)+' X '+str(dim_conv)+' X 3).')
 		if network==1:
-			print('The type of the Categorizer: Animation Analyzer (Lv '+str(level_tconv)+'; Shape '+str(dim_tconv)+' X '+str(channel)+').')		
+			print('The type of the Categorizer: Animation Analyzer (Lv '+str(level_tconv)+'; Shape '+str(dim_tconv)+' X '+str(channel)+').')
 		if network==2:
 			print('The type of the Categorizer: Animation Analyzer (Lv '+str(level_tconv)+'; Shape '+str(dim_tconv)+' X '+str(dim_tconv)+' X '+str(channel)+') + Pattern Recognizer (Lv '+str(level_conv)+'; Shape '+str(dim_conv)+' X '+str(dim_conv)+' X 3).')
 		length=int(parameters['time_step'][0])

--- a/LabGym/categorizer.py
+++ b/LabGym/categorizer.py
@@ -2038,5 +2038,3 @@ class Categorizers():
 				pd.DataFrame(report).transpose().to_excel(os.path.join(result_path,'testing_reports.xlsx'),float_format='%.2f')
 
 			print('Testing completed!')
-
-

--- a/LabGym/central_logging.py
+++ b/LabGym/central_logging.py
@@ -36,7 +36,7 @@ def cleanup(queue_listener):
 http_handler_config = {
     # Host and optional port
     # 'host': 'localhost:8080',
-    'host': 'solid-skill-463519-e0.appspot.com',  
+    'host': 'solid-skill-463519-e0.appspot.com',
     }
 
 http_handler_config.update({
@@ -45,7 +45,7 @@ http_handler_config.update({
     'method': 'POST',  # Specify POST method
 
     # Optional basic authentication
-    # 'credentials': ('username', 'password'),  
+    # 'credentials': ('username', 'password'),
     })
 
 
@@ -68,19 +68,19 @@ def reset_central_logger(logger):
 def get_central_logger(http_handler_config=http_handler_config, reset=False):
     """Return logger 'Central Logger', configured to send to an HTTP server.
 
-    Return logger 'Central Logger', configured to send log records to an 
+    Return logger 'Central Logger', configured to send log records to an
     HTTP server.
-    
-    Strength:  This implementation uses asynchronous handling of log 
+
+    Strength:  This implementation uses asynchronous handling of log
         records.  It uses QueueHandler/QueueListener and queue.Queue to
         let the HTTPHandler do its work on a separate thread.
 
-    References 
+    References
     [1] search: python logging send to url http post
         https://www.google.com/search?q=python+logging+send+to+url+http+post
 
         "Python's built-in logging module can send log records to an HTTP
-        server using the HTTPHandler class. This allows for centralized 
+        server using the HTTPHandler class. This allows for centralized
         log management by sending logs to a remote endpoint."
 
     Dev, with this file named sandbox.py
@@ -111,7 +111,7 @@ def get_central_logger(http_handler_config=http_handler_config, reset=False):
     central_logger.setLevel(logging.INFO)
 
     # Prepare a handler.
-    # An HTTPHandler doesn't use a Formatter, so using setFormatter() to 
+    # An HTTPHandler doesn't use a Formatter, so using setFormatter() to
     # specify a Formatter for an HTTPHandler has no effect.
     http_handler = logging.handlers.HTTPHandler(**http_handler_config)
 
@@ -120,7 +120,7 @@ def get_central_logger(http_handler_config=http_handler_config, reset=False):
     #     central_logger.addHandler(http_handler)
     #     # Milestone -- logrecord handling is configured.
     #
-    # But for this logger, we want non-blocking logging, where log 
+    # But for this logger, we want non-blocking logging, where log
     # records are queued and processed asynchronously.
     # So configure the logger to handle logrecords by putting them into
     # a queue and moving on.  Use a QueueListener running in a separate
@@ -130,18 +130,18 @@ def get_central_logger(http_handler_config=http_handler_config, reset=False):
     # Create a Queue obj.  This queue will store the LogRecord objects.
     logrecord_queue = queue.Queue(-1)  # -1 for an unbounded queue
 
-    # Create a QueueHandler obj.  Its sole purpose is to place LogRecord 
+    # Create a QueueHandler obj.  Its sole purpose is to place LogRecord
     # objects onto the Queue obj (logrecord_queue).
     queue_handler = logging.handlers.QueueHandler(logrecord_queue)
 
     # Attach the QueueHandler obj to the intended Logger obj.
     central_logger.addHandler(queue_handler)
 
-    # Create and Start a QueueListener obj.  This listener runs in a 
-    # separate thread, continuously monitors the logrecord_queue, and 
-    # dispatches the retrieved LogRecord objects to the configured 
+    # Create and Start a QueueListener obj.  This listener runs in a
+    # separate thread, continuously monitors the logrecord_queue, and
+    # dispatches the retrieved LogRecord objects to the configured
     # downstream handlers (http_handler).
-    queue_listener = logging.handlers.QueueListener(logrecord_queue, 
+    queue_listener = logging.handlers.QueueListener(logrecord_queue,
         http_handler)
     queue_listener.start()  # Start the listener thread
 
@@ -162,7 +162,7 @@ if __name__ == '__main__':  # pragma: no cover
     central_logger = get_central_logger()
 
     reginfo = {
-        'name': 'James Stewart', 
+        'name': 'James Stewart',
         'rank': 'Brigadier General',
         'serial number': 'O-433210',
         }

--- a/LabGym/central_logging.py
+++ b/LabGym/central_logging.py
@@ -15,7 +15,7 @@ import logging.handlers
 import queue
 
 # Related third party imports.
-# None
+# (none)
 
 # Local application/library specific imports.
 from LabGym import config

--- a/LabGym/config.py
+++ b/LabGym/config.py
@@ -7,8 +7,8 @@ Configuration evaluation involves (ordered in increasing precedence)
     4.  command-line options
 
 Notes
-*   Environment variables and command-line options can be used to 
-    override the location of the configuration file, so determine the 
+*   Environment variables and command-line options can be used to
+    override the location of the configuration file, so determine the
     configuration file location before reading it.
 
 *   Typical LabGym configdir organization is
@@ -85,15 +85,15 @@ def get_config_from_environ() -> dict:
     """Get config values from os.environ.
 
     Weaknesses
-    *   Environment variables are case-sensitive.  
-        There could be a collision when mapping names to lowercase, 
-        which should generate a warning or an exception, but that is not 
+    *   Environment variables are case-sensitive.
+        There could be a collision when mapping names to lowercase,
+        which should generate a warning or an exception, but that is not
         implemented.
-        As implemented, the retained value is the value of the 
+        As implemented, the retained value is the value of the
         environment variable whose name sorts higher.
     """
     prefix = 'LABGYM_'
-    result = {name.removeprefix(prefix).lower(): value 
+    result = {name.removeprefix(prefix).lower(): value
         for name, value in sorted(os.environ.items()) if name.startswith(prefix)}
     return result
 
@@ -133,23 +133,23 @@ def get_config():
     """Return a cached config dict. Construct it if necessary.
 
     Strengths
-    *   Instead of reconstructing the config dict each time this 
-        function is called, the config dict is determined the first time 
-        this function is run and then the function always returns the 
+    *   Instead of reconstructing the config dict each time this
+        function is called, the config dict is determined the first time
+        this function is run and then the function always returns the
         same value without reconstructing it.
         This implementation uses the common approach of using a module-
         level variable to store the value after its initial creation.
-        This pattern is often referred to as memoization or lazy 
+        This pattern is often referred to as memoization or lazy
         initialization.
 
     Weaknesses
-    *   Each override could be logged.  
-        The cost of implementation including unit test and complexity 
+    *   Each override could be logged.
+        The cost of implementation including unit test and complexity
         and maintainability may exceed benefit.
 
-    *   Provenances for all settings could be kept in a provenance 
+    *   Provenances for all settings could be kept in a provenance
         dictionary, and be logged before the function returns.
-        The cost of implementation including unit test and complexity 
+        The cost of implementation including unit test and complexity
         and maintainability may exceed benefit.
     """
 
@@ -186,7 +186,7 @@ def get_config():
     assert isinstance(configfile, Path)
 
     # # buffer some key/value pairs for late merge, to override.
-    # buf = {'configdir': configdir, 'configfile': configfile} 
+    # buf = {'configdir': configdir, 'configfile': configfile}
 
     if not os.path.isabs(configfile):
         configfile = configdir.joinpath(configfile)
@@ -195,7 +195,7 @@ def get_config():
     if not configfile.is_file() and provenance.get('configfile') != 'defaults':
         msg = f'Trouble reading user-specified configfile ({configfile})'
         sys.exit(msg)
-            
+
     config_from_configfile = get_config_from_configfile(configfile)
 
     # Aggregate 4 dicts.  Use myupdate instead of dict update method.
@@ -214,7 +214,7 @@ def get_config():
 def myupdate(target: dict, addendum: dict) -> None:
     """..."""
 
-    # if the addendum has 'enable' dict, then merge the existing 
+    # if the addendum has 'enable' dict, then merge the existing
     # target['enable'] into addendum['enable'] before target.update()
 
     if target.get('enable') is not None and addendum.get('enable') is not None:
@@ -222,15 +222,15 @@ def myupdate(target: dict, addendum: dict) -> None:
         buf.update(target['enable'])
         buf.update(addendum['enable'])
         addendum['enable'] = buf
-    
+
     target.update(addendum)
 
 
 def mypathexpand(target: dict) -> None:
     """
     For all items in the target that should be Path objects, ensure
-    they are absolute paths.  
-    Overrides from environment variables need to be converted from str 
+    they are absolute paths.
+    Overrides from environment variables need to be converted from str
     to Path, and, relative paths need to be anchored to configdir.
     """
     if not isinstance(target['configdir'], Path):

--- a/LabGym/detector.py
+++ b/LabGym/detector.py
@@ -213,5 +213,3 @@ class Detector():
 			outputs=self.current_detector(inputs)
 
 		return outputs
-
-

--- a/LabGym/detector.py
+++ b/LabGym/detector.py
@@ -16,24 +16,25 @@ USA
 Email: bingye@umich.edu
 '''
 
-
-
-
-import os
-import cv2
+# Standard library imports.
 import json
-import torch
+import os
+
+# Related third party imports.
+import cv2
 from .detectron2 import model_zoo
 from .detectron2.checkpoint import DetectionCheckpointer
 from .detectron2.config import get_cfg
 from .detectron2.data import MetadataCatalog,DatasetCatalog,build_detection_test_loader
 from .detectron2.data.datasets import register_coco_instances
 from .detectron2.engine import DefaultTrainer,DefaultPredictor
-from .detectron2.utils.visualizer import Visualizer
 from .detectron2.evaluation import COCOEvaluator,inference_on_dataset
 from .detectron2.modeling import build_model
+from .detectron2.utils.visualizer import Visualizer
+import torch
 
-
+# Local application/library specific imports.
+# (none)
 
 
 class Detector():

--- a/LabGym/detector.py
+++ b/LabGym/detector.py
@@ -2,7 +2,7 @@
 Copyright (C)
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-You should have received a copy of the GNU General Public License along with this program. If not, see https://tldrlegal.com/license/gnu-general-public-license-v3-(gpl-3)#fulltext. 
+You should have received a copy of the GNU General Public License along with this program. If not, see https://tldrlegal.com/license/gnu-general-public-license-v3-(gpl-3)#fulltext.
 
 For license issues, please contact:
 
@@ -103,7 +103,7 @@ class Detector():
 		trainer.train()
 
 		model_parameters=os.path.join(cfg.OUTPUT_DIR,'model_parameters.txt')
-		
+
 		model_parameters_dict['animal_mapping']={}
 		model_parameters_dict['inferencing_framesize']=int(inference_size)
 

--- a/LabGym/detector.py
+++ b/LabGym/detector.py
@@ -141,7 +141,7 @@ class Detector():
 		register_coco_instances('LabGym_detector_test',{},path_to_annotation,path_to_testingimages)
 
 		datasetcat=DatasetCatalog.get('LabGym_detector_test')
-		metadatacat=MetadataCatalog.get('LabGym_detector_test')
+		# metadatacat=MetadataCatalog.get('LabGym_detector_test')
 
 		animalmapping=os.path.join(path_to_detector,'model_parameters.txt')
 

--- a/LabGym/gui_analyzer.py
+++ b/LabGym/gui_analyzer.py
@@ -2,7 +2,7 @@
 Copyright (C)
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-You should have received a copy of the GNU General Public License along with this program. If not, see https://tldrlegal.com/license/gnu-general-public-license-v3-(gpl-3)#fulltext. 
+You should have received a copy of the GNU General Public License along with this program. If not, see https://tldrlegal.com/license/gnu-general-public-license-v3-(gpl-3)#fulltext.
 
 For license issues, please contact:
 
@@ -821,7 +821,7 @@ class WindowLv2_AnalyzeBehaviors(wx.Frame):
 			colors=[]
 			for c in complete_colors:
 				colors.append(['#ffffff',c])
-			
+
 			dialog=wx.MessageDialog(self,'Specify the color to represent\nthe behaviors in annotations and plots?','Specify colors for behaviors?',wx.YES_NO|wx.ICON_QUESTION)
 			if dialog.ShowModal()==wx.ID_YES:
 				names_colors={}
@@ -985,7 +985,7 @@ class WindowLv2_AnalyzeBehaviors(wx.Frame):
 								self.animal_number[animal_name]=1
 						else:
 							self.animal_number=1
-				
+
 					if self.path_to_categorizer is None:
 						self.behavior_mode=0
 						categorize_behavior=False
@@ -1044,7 +1044,7 @@ class WindowLv2_AnalyzeBehaviors(wx.Frame):
 									all_events[animal_name][len(all_events[animal_name])]=AAD.event_probability[animal_name][n]
 							if len(all_time)<len(AAD.all_time):
 								all_time=AAD.all_time
-					
+
 				if self.path_to_categorizer is not None:
 
 					max_length=len(all_time)
@@ -1196,8 +1196,8 @@ class WindowLv2_MineResults(wx.Frame):
 			self.control=None
 			self.text_selectcontrol.SetLabel('No control group.')
 		dialog.Destroy()
-		
-		 
+
+
 	def select_result_path(self,event):
 
 		dialog=wx.DirDialog(self,'Select a directory','',style=wx.DD_DEFAULT_STYLE)
@@ -1250,7 +1250,7 @@ class WindowLv2_MineResults(wx.Frame):
 		self.dataset.pop(del_idx)
 		self.file_names.insert(0,self.file_names.pop(del_idx))
 
-	
+
 	def mine_data(self,event):
 
 		if self.file_path is None or self.result_path is None:
@@ -1352,7 +1352,7 @@ class WindowLv2_PlotBehaviors(wx.Frame):
 			self.text_inputfile.SetLabel(f'all_events.xlsx path: {all_events_file}')
 		dialog.Destroy()
 
-		 
+
 	def select_result_path(self,event):
 
 		dialog=wx.DirDialog(self,'Select a directory','',style=wx.DD_DEFAULT_STYLE)
@@ -1375,7 +1375,7 @@ class WindowLv2_PlotBehaviors(wx.Frame):
 					self.names_and_colors[behavior]=('#ffffff',new_color)
 			self.text_selectcolors.SetLabel('Colors: '+', '.join([f'{behavior}:{color}' for behavior,(_,color) in self.names_and_colors.items()]))
 
-	
+
 	def plot_behavior(self,event):
 
 		if self.events_probability is None or self.time_points is None or self.results_folder is None or self.names_and_colors is None:

--- a/LabGym/gui_analyzer.py
+++ b/LabGym/gui_analyzer.py
@@ -1244,7 +1244,7 @@ class WindowLv2_MineResults(wx.Frame):
 
 	def control_organization(self):
 
-		if self.control==None:
+		if self.control is None:
 			return
 		del_idx=self.file_names.index(self.control_file_name)
 		self.dataset.pop(del_idx)

--- a/LabGym/gui_analyzer.py
+++ b/LabGym/gui_analyzer.py
@@ -1525,5 +1525,3 @@ class WindowLv2_CalculateDistances(wx.Frame):
 				all_data=pd.concat(all_data,keys=names,names=['File name','ID/parameter'])
 				all_data.drop(all_data.columns[0],axis=1,inplace=True)
 				all_data.to_excel(os.path.join(self.out_path,'all_summary.xlsx'),float_format='%.2f')
-
-

--- a/LabGym/gui_analyzer.py
+++ b/LabGym/gui_analyzer.py
@@ -16,32 +16,32 @@ USA
 Email: bingye@umich.edu
 '''
 
+# Standard library imports.
+import logging
+import json
+import os
+from pathlib import Path
+
 # Log the load of this module (by the module loader, on first import).
 # Intentionally positioning these statements before other imports, against the
 # guidance of PEP-8, to log the load before other imports log messages.
-import logging
-logger =  logging.getLogger(__name__)
-logger.debug('loading %s', __file__)
+logger =  logging.getLogger(__name__)  # pylint: disable=wrong-import-position
+logger.debug('loading %s', __file__)  # pylint: disable=wrong-import-position
 
-
-
-
-import wx
-import os
+# Related third party imports.
 import matplotlib as mpl
-from pathlib import Path
 import pandas as pd
 import torch
-import json
+import wx
+
+# Local application/library specific imports.
 from .analyzebehavior import AnalyzeAnimal
 from .analyzebehavior_dt import AnalyzeAnimalDetector
-from .tools import plot_events,parse_all_events_file,calculate_distances
 from .minedata import data_mining
-
+from .tools import plot_events,parse_all_events_file,calculate_distances
 
 
 the_absolute_current_path=str(Path(__file__).resolve().parent)
-
 
 
 class ColorPicker(wx.Dialog):

--- a/LabGym/gui_categorizer.py
+++ b/LabGym/gui_categorizer.py
@@ -2,7 +2,7 @@
 Copyright (C)
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-You should have received a copy of the GNU General Public License along with this program. If not, see https://tldrlegal.com/license/gnu-general-public-license-v3-(gpl-3)#fulltext. 
+You should have received a copy of the GNU General Public License along with this program. If not, see https://tldrlegal.com/license/gnu-general-public-license-v3-(gpl-3)#fulltext.
 
 For license issues, please contact:
 
@@ -619,9 +619,9 @@ class WindowLv2_GenerateExamples(wx.Frame):
 				dialog.Destroy()
 
 				if do_nothing is False:
-		
+
 					for i in self.path_to_videos:
-					
+
 						filename=os.path.splitext(os.path.basename(i))[0].split('_')
 						if self.decode_animalnumber:
 							if self.use_detector:
@@ -1058,7 +1058,7 @@ class WindowLv2_TrainCategorizers(wx.Frame):
 
 		super(WindowLv2_TrainCategorizers,self).__init__(parent=None,title=title,size=(1000,540))
 		self.file_path=None # the folder that stores sorted, unprepared behavior examples (each category is a subfolder)
-		self.new_path=None # the folder that stores prepared behavior examples (contains all examples with a category tag in their names) 
+		self.new_path=None # the folder that stores prepared behavior examples (contains all examples with a category tag in their names)
 		self.behavior_mode=0 # 0--non-interactive, 1--interactive basic, 2--interactive advanced, 3--static images
 		self.animation_analyzer=True # whether to include Animation Analyzer in the Categorizers
 		self.level_tconv=2 # complexity level of Animation Analyzer in Categorizer
@@ -1364,7 +1364,7 @@ class WindowLv2_TrainCategorizers(wx.Frame):
 
 		dialog=wx.DirDialog(self,'Select a directory','',style=wx.DD_DEFAULT_STYLE)
 		if dialog.ShowModal()==wx.ID_OK:
-			self.data_path=dialog.GetPath()			
+			self.data_path=dialog.GetPath()
 		dialog.Destroy()
 
 		if self.data_path is None:
@@ -1391,7 +1391,7 @@ class WindowLv2_TrainCategorizers(wx.Frame):
 					self.background_free=False
 					self.text_trainingfolder.SetLabel('Static images w/ background in: '+self.data_path+'.')
 				dialog.Destroy()
-		
+
 			else:
 
 				if self.animation_analyzer:
@@ -1479,7 +1479,7 @@ class WindowLv2_TrainCategorizers(wx.Frame):
 				selected='none'
 			else:
 				if self.aug_methods[0]=='default':
-					self.aug_methods=['random rotation','horizontal flipping','vertical flipping','random brightening','random dimming']	
+					self.aug_methods=['random rotation','horizontal flipping','vertical flipping','random brightening','random dimming']
 			dialog.Destroy()
 
 			dialog=wx.MessageDialog(self,'Also augment the validation data?\nSelect "No" if dont know what it is.','Augment validation data?',wx.YES_NO|wx.ICON_QUESTION)
@@ -1521,7 +1521,7 @@ class WindowLv2_TrainCategorizers(wx.Frame):
 		else:
 
 			do_nothing=False
-				
+
 			stop=False
 			while stop is False:
 				dialog=wx.TextEntryDialog(self,'Enter a name for the Categorizer to train','Categorizer name')
@@ -1670,7 +1670,7 @@ class WindowLv2_TestCategorizers(wx.Frame):
 		if dialog.ShowModal()==wx.ID_OK:
 			self.file_path=dialog.GetPath()
 			self.text_inputexamples.SetLabel('Path to ground-truth behavior examples: '+self.file_path+'.')
-		dialog.Destroy()	
+		dialog.Destroy()
 
 
 	def select_reportpath(self,event):

--- a/LabGym/gui_categorizer.py
+++ b/LabGym/gui_categorizer.py
@@ -1715,5 +1715,3 @@ class WindowLv2_TestCategorizers(wx.Frame):
 				shutil.rmtree(os.path.join(self.model_path,categorizer))
 			dialog1.Destroy()
 		dialog.Destroy()
-
-

--- a/LabGym/gui_categorizer.py
+++ b/LabGym/gui_categorizer.py
@@ -16,39 +16,36 @@ USA
 Email: bingye@umich.edu
 '''
 
+# Standard library imports.
+import json
+import logging
+import os
+from pathlib import Path
+import shutil
+
 # Log the load of this module (by the module loader, on first import).
 # Intentionally positioning these statements before other imports, against the
 # guidance of PEP-8, to log the load before other imports log messages.
-import logging
-logger =  logging.getLogger(__name__)
-logger.debug('loading %s', __file__)
+logger =  logging.getLogger(__name__)  # pylint: disable=wrong-import-position
+logger.debug('loading %s', __file__)  # pylint: disable=wrong-import-position
 
-
-
-
-import wx
-import os
-import shutil
-from pathlib import Path
-import json
+# Related third party imports.
 import cv2
 import numpy as np
+import wx
 
+# Local application/library specific imports.
 logger.debug('importing %s ...', '.analyzebehavior')
 from .analyzebehavior import AnalyzeAnimal
 logger.debug('importing %s done', '.analyzebehavior')
-
 logger.debug('importing %s ...', '.analyzebehavior_dt')
 from .analyzebehavior_dt import AnalyzeAnimalDetector
 logger.debug('importing %s done', '.analyzebehavior_dt')
-
 from .categorizer import Categorizers
 from .tools import sort_examples_from_csv
 
 
-
 the_absolute_current_path=str(Path(__file__).resolve().parent)
-
 
 
 class WindowLv2_GenerateExamples(wx.Frame):

--- a/LabGym/gui_detector.py
+++ b/LabGym/gui_detector.py
@@ -16,30 +16,30 @@ USA
 Email: bingye@umich.edu
 '''
 
+# Standard library imports.
+import json
+import logging
+from pathlib import Path
+import os
+import shutil
+
 # Log the load of this module (by the module loader, on first import).
 # Intentionally positioning these statements before other imports, against the
 # guidance of PEP-8, to log the load before other imports log messages.
-import logging
-logger =  logging.getLogger(__name__)
-logger.debug('loading %s', __file__)
+logger =  logging.getLogger(__name__)  # pylint: disable=wrong-import-position
+logger.debug('loading %s', __file__)  # pylint: disable=wrong-import-position
 
-
-
-from .tools import extract_frames
-from .detector import Detector
-from pathlib import Path
+# Related third party imports.
 import wx
-import os
-import cv2
-import json
-import shutil
-import torch
+# import cv2
+# import torch
 
-
+# Local application/library specific imports.
+from .detector import Detector
+from .tools import extract_frames
 
 
 the_absolute_current_path=str(Path(__file__).resolve().parent)
-
 
 
 class WindowLv2_GenerateImages(wx.Frame):

--- a/LabGym/gui_detector.py
+++ b/LabGym/gui_detector.py
@@ -2,7 +2,7 @@
 Copyright (C)
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-You should have received a copy of the GNU General Public License along with this program. If not, see https://tldrlegal.com/license/gnu-general-public-license-v3-(gpl-3)#fulltext. 
+You should have received a copy of the GNU General Public License along with this program. If not, see https://tldrlegal.com/license/gnu-general-public-license-v3-(gpl-3)#fulltext.
 
 For license issues, please contact:
 
@@ -336,7 +336,7 @@ class WindowLv2_TrainDetectors(wx.Frame):
 			self.inference_size=int(dialog.GetValue())
 			self.text_inferencingsize.SetLabel('Inferencing frame size: '+str(self.inference_size)+'.')
 		dialog.Destroy()
-		
+
 
 	def input_iterations(self,event):
 

--- a/LabGym/gui_detector.py
+++ b/LabGym/gui_detector.py
@@ -547,6 +547,3 @@ class WindowLv2_TestDetectors(wx.Frame):
 				shutil.rmtree(os.path.join(self.detector_path,detector))
 			dialog1.Destroy()
 		dialog.Destroy()
-
-
-

--- a/LabGym/gui_main.py
+++ b/LabGym/gui_main.py
@@ -337,7 +337,7 @@ class WindowLv1_AnalysisModule(wx.Frame):
 
 def main_window():
 
-	the_absolute_current_path=str(Path(__file__).resolve().parent)
+	# the_absolute_current_path=str(Path(__file__).resolve().parent)
 	app=wx.App()
 	InitialWindow(f'LabGym v{__version__}')
 	logger.info('The user interface initialized!')

--- a/LabGym/gui_main.py
+++ b/LabGym/gui_main.py
@@ -16,31 +16,30 @@ USA
 Email: bingye@umich.edu
 '''
 
+# Standard library imports.
+# import json
+import logging
+from pathlib import Path
+# from urllib import request
+
 # Log the load of this module (by the module loader, on first import).
 # Intentionally positioning these statements before other imports, against the
 # guidance of PEP-8, to log the load before other imports log messages.
-import logging
-logger =  logging.getLogger(__name__)
-logger.debug('loading %s', __file__)
+logger =  logging.getLogger(__name__)  # pylint: disable=wrong-import-position
+logger.debug('loading %s', __file__)  # pylint: disable=wrong-import-position
 
-
-
-
+# Related third party imports.
 import wx
 import wx.lib.agw.hyperlink as hl
-import json
-from urllib import request
-from pathlib import Path
 
+# Local application/library specific imports.
+from LabGym import __version__
 logger.debug('importing %s ...', '.gui_categorizer')
 from .gui_categorizer import WindowLv2_GenerateExamples,WindowLv2_TrainCategorizers,WindowLv2_SortBehaviors,WindowLv2_TestCategorizers
 logger.debug('importing %s done', '.gui_categorizer')
-
 from .gui_detector import WindowLv2_GenerateImages,WindowLv2_TrainDetectors,WindowLv2_TestDetectors
 from .gui_preprocessor import WindowLv2_ProcessVideos,WindowLv2_DrawMarkers
 from .gui_analyzer import WindowLv2_AnalyzeBehaviors,WindowLv2_MineResults,WindowLv2_PlotBehaviors,WindowLv2_CalculateDistances
-from LabGym import __version__
-
 
 
 class InitialWindow(wx.Frame):
@@ -346,6 +345,6 @@ def main_window():
 
 
 
-if __name__=='__main__':
+if __name__=='__main__':  # pragma: no cover
 
 	main_window()

--- a/LabGym/gui_main.py
+++ b/LabGym/gui_main.py
@@ -349,5 +349,3 @@ def main_window():
 if __name__=='__main__':
 
 	main_window()
-
-

--- a/LabGym/gui_main.py
+++ b/LabGym/gui_main.py
@@ -2,7 +2,7 @@
 Copyright (C)
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-You should have received a copy of the GNU General Public License along with this program. If not, see https://tldrlegal.com/license/gnu-general-public-license-v3-(gpl-3)#fulltext. 
+You should have received a copy of the GNU General Public License along with this program. If not, see https://tldrlegal.com/license/gnu-general-public-license-v3-(gpl-3)#fulltext.
 
 For license issues, please contact:
 
@@ -68,7 +68,7 @@ class InitialWindow(wx.Frame):
 			label='Created by Yujia Hu and Bing Ye\n\nLife Sciences Institute, University of Michigan\n\n\n\nContributor list:\n\nJie Zhou, Rohan Satapathy, John Ruckstuhl, Brendon O. Waston, Carrie R. Ferrario,\n\nKelly Goss, Isabelle Baker, M. Victor Struman, Bobby Tomlinson',style=wx.ALIGN_CENTER|wx.ST_ELLIPSIZE_END)
 		boxsizer.Add(self.text_developers,0,wx.LEFT|wx.RIGHT|wx.EXPAND,5)
 		boxsizer.Add(0,60,0)
-		
+
 		links=wx.BoxSizer(wx.HORIZONTAL)
 		homepage=hl.HyperLinkCtrl(panel,0,'Home Page',URL='https://github.com/umyelab/LabGym')
 		userguide=hl.HyperLinkCtrl(panel,0,'Extended Guide',URL='https://github.com/yujiahu415/LabGym/blob/master/LabGym_extended_user_guide.pdf')

--- a/LabGym/gui_preprocessor.py
+++ b/LabGym/gui_preprocessor.py
@@ -784,7 +784,3 @@ class WindowLv3_DrawMarkers(wx.Frame):
 
 
 			print('Marker Drawing completed!')
-
-
-
-

--- a/LabGym/gui_preprocessor.py
+++ b/LabGym/gui_preprocessor.py
@@ -2,7 +2,7 @@
 Copyright (C)
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-You should have received a copy of the GNU General Public License along with this program. If not, see https://tldrlegal.com/license/gnu-general-public-license-v3-(gpl-3)#fulltext. 
+You should have received a copy of the GNU General Public License along with this program. If not, see https://tldrlegal.com/license/gnu-general-public-license-v3-(gpl-3)#fulltext.
 
 For license issues, please contact:
 
@@ -237,7 +237,7 @@ class WindowLv2_ProcessVideos(wx.Frame):
 
 			if self.framewidth is not None:
 				frame=cv2.resize(frame,(self.framewidth,int(frame.shape[0]*self.framewidth/frame.shape[1])),interpolation=cv2.INTER_AREA)
-			
+
 			canvas=np.copy(frame)
 			h,w=frame.shape[:2]
 			for y in range(0,h,50):
@@ -278,7 +278,7 @@ class WindowLv2_ProcessVideos(wx.Frame):
 				dialog.Destroy()
 
 			cv2.destroyAllWindows()
-			
+
 
 	def enhance_videos(self,event):
 

--- a/LabGym/gui_preprocessor.py
+++ b/LabGym/gui_preprocessor.py
@@ -16,22 +16,24 @@ USA
 Email: bingye@umich.edu
 '''
 
+# Standard library imports.
+import logging
+import os
+
 # Log the load of this module (by the module loader, on first import).
 # Intentionally positioning these statements before other imports, against the
 # guidance of PEP-8, to log the load before other imports log messages.
-import logging
-logger =  logging.getLogger(__name__)
-logger.debug('loading %s', __file__)
+logger =  logging.getLogger(__name__)  # pylint: disable=wrong-import-position
+logger.debug('loading %s', __file__)  # pylint: disable=wrong-import-position
 
-
-
-from .tools import preprocess_video
-import wx
-import os
+# Related third party imports.
 import cv2
 import numpy as np
 from PIL import Image,ImageEnhance
+import wx
 
+# Local application/library specific imports.
+from .tools import preprocess_video
 
 
 class WindowLv2_ProcessVideos(wx.Frame):

--- a/LabGym/minedata.py
+++ b/LabGym/minedata.py
@@ -53,7 +53,7 @@ class data_mining():
 
 	def two_groups(self):
 
-		if self.control!=None:
+		if self.control is not None:
 			self.data.insert(0, self.control)
 
 		for behavior in self.data[0]:
@@ -117,7 +117,7 @@ class data_mining():
 					currentSet=self.data[i][behavior][parameter].dropna()
 					dataset.append(currentSet)
 
-				if self.control!=None:
+				if self.control is not None:
 					currentSet=self.control[behavior][parameter].dropna()
 					dataset.insert(0,currentSet)
 
@@ -154,7 +154,7 @@ class data_mining():
 
 					if test=='ANOVA':
 
-						if self.control==None:
+						if self.control is None:
 							tukey=stats.tukey_hsd(*dataset)
 							print(tukey)
 							posthoc_name='Tukey'
@@ -189,7 +189,7 @@ class data_mining():
 
 	def statistical_analysis(self):
 
-		if (len(self.data)==2 and self.control==None) or (len(self.data)==1 and self.control!=None): # tests for two groups only
+		if (len(self.data)==2 and self.control is None) or (len(self.data)==1 and self.control is not None): # tests for two groups only
 
 			self.two_groups()
 

--- a/LabGym/minedata.py
+++ b/LabGym/minedata.py
@@ -198,5 +198,3 @@ class data_mining():
 		self.writer.close()
 
 		print('Data mining for statistical analysis completed!')
-
-

--- a/LabGym/minedata.py
+++ b/LabGym/minedata.py
@@ -13,16 +13,18 @@ USA
 Email: bingye@umich.edu
 '''
 
-
-
-
-import scipy
-from scipy import stats
-import scikit_posthocs as sp
-import pandas as pd
+# Standard library imports.
 import os
-import openpyxl
 
+# Related third party imports.
+# import openpyxl
+import pandas as pd
+import scikit_posthocs as sp
+# import scipy
+from scipy import stats
+
+# Local application/library specific imports.
+# (none)
 
 
 class data_mining():

--- a/LabGym/minedata.py
+++ b/LabGym/minedata.py
@@ -2,7 +2,7 @@
 Copyright (C)
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-You should have received a copy of the GNU General Public License along with this program. If not, see https://tldrlegal.com/license/gnu-general-public-license-v3-(gpl-3)#fulltext. 
+You should have received a copy of the GNU General Public License along with this program. If not, see https://tldrlegal.com/license/gnu-general-public-license-v3-(gpl-3)#fulltext.
 For license issues, please contact:
 Dr. Bing Ye
 Life Sciences Institute
@@ -171,7 +171,7 @@ class data_mining():
 
 					else:
 
-						dunn=sp.posthoc_dunn(dataset) 
+						dunn=sp.posthoc_dunn(dataset)
 						dunn.columns=self.file_names
 						dunn.index=self.file_names
 						print('\t'*2,'Dunns post-hoc results:')

--- a/LabGym/myargparse.py
+++ b/LabGym/myargparse.py
@@ -21,8 +21,10 @@ import sys
 import textwrap
 from typing import List, Union, Dict, Any
 
+# Related third party imports.
+# (none)
+
 # Local application/library specific imports.
-# import LabGym.__version__ as version
 from LabGym import __version__ as version
 
 

--- a/LabGym/mylogging.py
+++ b/LabGym/mylogging.py
@@ -105,8 +105,8 @@ from __future__ import annotations
 # Standard library imports.
 import functools
 import inspect
-import logging.config, logging.handlers
-import os
+import logging.config
+import logging.handlers
 from pathlib import Path
 # import pprint
 import queue

--- a/LabGym/mypkg_resources.py
+++ b/LabGym/mypkg_resources.py
@@ -13,11 +13,11 @@ with warnings.catch_warnings():
 #
 # LabGym and detectron2 presently (2025-07-28) use the pkg_resources
 # package in a single module, detectron2/model_zoo/model_zoo.py.
-#      4	import pkg_resources
+#      4  import pkg_resources
 #         ...
-#    139	    cfg_file = pkg_resources.resource_filename(
-#    140	        "detectron2.model_zoo", os.path.join("configs", config_path)
-#    141	    )
+#    139      cfg_file = pkg_resources.resource_filename(
+#    140          "detectron2.model_zoo", os.path.join("configs", config_path)
+#    141      )
 #
 # The pkg_resources package is deprecated.
 # When loaded, the pkg_resources package produces a user-facing warning.

--- a/LabGym/mypkg_resources.py
+++ b/LabGym/mypkg_resources.py
@@ -10,67 +10,67 @@ with warnings.catch_warnings():
 
 
 # """Provide a replacement for the deprecated pkg_resources package.
-# 
-# LabGym and detectron2 presently (2025-07-28) use the pkg_resources 
+#
+# LabGym and detectron2 presently (2025-07-28) use the pkg_resources
 # package in a single module, detectron2/model_zoo/model_zoo.py.
 #      4	import pkg_resources
 #         ...
 #    139	    cfg_file = pkg_resources.resource_filename(
 #    140	        "detectron2.model_zoo", os.path.join("configs", config_path)
 #    141	    )
-# 
+#
 # The pkg_resources package is deprecated.
 # When loaded, the pkg_resources package produces a user-facing warning.
-# 
+#
 # However, if this module is loaded before the genuine pkg_resources is loaded,
-# then 
+# then
 # 1.  the warning message is caught/suppressed,
 # 2.  references to pkg_resources are mapped to this module, so
 #     pkg_resources.resource_filename refers to the function defined here.
-# 
-# After this module is tested, 
+#
+# After this module is tested,
 # to show that the new_result follows the old_result,
 # the load of pkg_resources can be eliminated, and we can rely on the new_result.
 # """
-# 
+#
 # import importlib.resources
 # import logging
 # import sys
 # import warnings
-# 
-# 
+#
+#
 # logger = logging.getLogger(__name__)
 # logger.debug('pkg_resources -- Loading...')
 # with warnings.catch_warnings():
 #     warnings.simplefilter('ignore')  # Ignore all warnings
 #     from pkg_resources import resource_filename as old_resource_filename
 # logger.debug('pkg_resources -- Loaded')
-# 
-# 
-# logger.debug('%s: %r', 
+#
+#
+# logger.debug('%s: %r',
 #     "sys.modules['pkg_resources']", sys.modules['pkg_resources'])
-# logger.debug('%s: %r', 
+# logger.debug('%s: %r',
 #     "sys.modules.get(__name__)", sys.modules.get(__name__))
 # sys.modules['pkg_resources'] = sys.modules.get(__name__)
-# 
-# 
+#
+#
 # def resource_filename(*args, **kwargs):
 #     logger.debug('old_resource_filename() -- Calling')
 #     logger.debug('%s: %r', 'args', args)
 #     logger.debug('%s: %r', 'kwargs', kwargs)
 #     old_result = old_resource_filename(*args, **kwargs)
 #     logger.debug('%s: %r', 'old_result', old_result)
-# 
+#
 #     # re-implement with importlib.resources.files()
-#     try: 
+#     try:
 #         new_result = str(importlib.resources.files(args[0]) / args[1])
 #         logger.debug('%s: %r', 'new_result', new_result)
-# 
+#
 #         if new_result == old_result:
 #             logger.info(f'agreement {new_result}')
 #         else:
 #             logger.info(f'disagreement {new_result}, {old_result}')
 #     except:
 #         logger.warning(e)
-# 
+#
 #     return old_result

--- a/LabGym/probes.py
+++ b/LabGym/probes.py
@@ -136,7 +136,7 @@ def probe_url_to_verify_cacert() -> None:
     On 2025-05-19 Google AI says,
         Detectron2 relies on dl.fbaipublicfiles.com for distributing
         pre-built binaries and model weights.
-        If you're using the pre-built versions of Detectron2 or 
+        If you're using the pre-built versions of Detectron2 or
         downloading pre-trained models, your system will likely be
         downloading files from dl.fbaipublicfiles.com.
     """

--- a/LabGym/probes.py
+++ b/LabGym/probes.py
@@ -8,15 +8,9 @@ sw and its configuration, and outside resources.
 from __future__ import annotations
 
 # Standard library imports.
-# import inspect
-import getpass
-# import json
+# import getpass
 import logging
-# import os
-# from pathlib import Path
 import platform
-# import sys
-
 
 # Log the load of this module (by the module loader, on first import).
 #
@@ -29,7 +23,6 @@ logger = logging.getLogger(__name__)
 logger.debug('%s', f'loading {__file__}')
 logger.debug('%s: %r', '(__name__, __package__)', (__name__, __package__))
 # pylint: enable=wrong-import-position
-
 
 # Related third party imports.
 import certifi  # Python package for providing Mozilla's CA Bundle.

--- a/LabGym/tests/INIT.sh
+++ b/LabGym/tests/INIT.sh
@@ -3,7 +3,8 @@
 # Usage
 #     source INIT.sh
 
-ERROR () { printf "ERROR: %s\n" "$*" >& 2; }
+ERROR () { printf "ERROR\t%s\n" "$(printf "$@")" >& 2; }
+DEBUG () { printf "DEBUG\t%s\n" "$(printf "$@")" >& 2; }
 
 IS_VENV () { [ -n "$VIRTUAL_ENV+1" ]; }  # works in sh, bash, and zsh
     

--- a/LabGym/tests/INIT.sh
+++ b/LabGym/tests/INIT.sh
@@ -1,0 +1,16 @@
+# INIT -- Define ERROR, IS_VENV functions.  Define PYFILES.
+#
+# Usage
+#     source INIT.sh
+
+ERROR () { printf "ERROR: %s\n" "$*" >& 2; }
+
+IS_VENV () { [ -n "$VIRTUAL_ENV+1" ]; }  # works in sh, bash, and zsh
+    
+PYFILES=$(cd .. && echo *.py)
+# printf "%s: %s\n" "\$PYFILES" "$PYFILES"
+
+return
+# if return failed, then this script is being executed in its own shell
+ERROR "bad usage -- source $0 instead of executing it in its own shell"
+exit 1

--- a/LabGym/tests/pylint.Notes.txt
+++ b/LabGym/tests/pylint.Notes.txt
@@ -18,22 +18,22 @@ A summary of pylint results looks like this,
 with a quality metric in col 2,
 and an observations-count in col 3.
      1	10.00/10  3     __init__.py
-     2	7.27/10   13    __main__.py
-     3	8.23/10   166   analyzebehavior.py
-     4	8.68/10   217   analyzebehavior_dt.py
-     5	7.30/10   255   categorizer.py
-     6	7.29/10   17    central_logging.py
-     7	8.93/10   15    config.py
-     8	7.36/10   30    detector.py
-     9	8.59/10   156   gui_analyzer.py
-    10	8.59/10   172   gui_categorizer.py
-    11	7.98/10   82    gui_detector.py
-    12	6.77/10   67    gui_main.py
-    13	8.60/10   78    gui_preprocessor.py
-    14	7.56/10   31    minedata.py
+     2	7.58/10   12    __main__.py
+     3	8.44/10   145   analyzebehavior.py
+     4	8.81/10   193   analyzebehavior_dt.py
+     5	7.39/10   243   categorizer.py
+     6	8.96/10   9     central_logging.py
+     7	9.42/10   10    config.py
+     8	7.52/10   28    detector.py
+     9	8.66/10   147   gui_analyzer.py
+    10	8.67/10   163   gui_categorizer.py
+    11	8.03/10   80    gui_detector.py
+    12	6.87/10   65    gui_main.py
+    13	8.66/10   75    gui_preprocessor.py
+    14	7.64/10   30    minedata.py
     15	9.50/10   7     myargparse.py
     16	8.35/10   21    mylogging.py
     17	7.50/10   5     mypkg_resources.py
     18	8.12/10   13    probes.py
     19	8.52/10   16    registration.py
-    20	8.57/10   112   tools.py
+    20	8.77/10   94    tools.py

--- a/LabGym/tests/pylint.Notes.txt
+++ b/LabGym/tests/pylint.Notes.txt
@@ -18,22 +18,22 @@ A summary of pylint results looks like this,
 with a quality metric in col 2,
 and an observations-count in col 3.
      1	10.00/10  3     __init__.py
-     2	7.58/10   12    __main__.py
-     3	8.44/10   145   analyzebehavior.py
-     4	8.81/10   193   analyzebehavior_dt.py
-     5	7.39/10   243   categorizer.py
+     2	9.39/10   6     __main__.py
+     3	8.93/10   108   analyzebehavior.py
+     4	9.00/10   170   analyzebehavior_dt.py
+     5	8.30/10   175   categorizer.py
      6	8.96/10   9     central_logging.py
      7	9.42/10   10    config.py
      8	7.52/10   28    detector.py
-     9	8.66/10   147   gui_analyzer.py
-    10	8.67/10   163   gui_categorizer.py
-    11	8.03/10   80    gui_detector.py
-    12	6.87/10   65    gui_main.py
-    13	8.66/10   75    gui_preprocessor.py
-    14	7.64/10   30    minedata.py
+     9	8.79/10   133   gui_analyzer.py
+    10	8.79/10   148   gui_categorizer.py
+    11	8.49/10   62    gui_detector.py
+    12	7.67/10   49    gui_main.py
+    13	8.86/10   64    gui_preprocessor.py
+    14	7.84/10   27    minedata.py
     15	9.50/10   7     myargparse.py
-    16	8.35/10   21    mylogging.py
+    16	8.54/10   19    mylogging.py
     17	7.50/10   5     mypkg_resources.py
-    18	8.12/10   13    probes.py
+    18	8.30/10   12    probes.py
     19	8.52/10   16    registration.py
-    20	8.77/10   94    tools.py
+    20	9.09/10   69    tools.py

--- a/LabGym/tests/pylint.Notes.txt
+++ b/LabGym/tests/pylint.Notes.txt
@@ -1,0 +1,39 @@
+2025-08-25
+*   Pylint is a static code analysis tool.
+    https://pylint.readthedocs.io/en/latest/
+*   pylint.sh is a homegrown convenience wrapper for running pylint.
+
+1.  Install pylint
+        pip install pylint
+
+2.  Run pylint.sh from this dir to pylint all ../*.py, like
+        sh pylint.sh
+    or pylint specific file(s), like
+        sh pylint.sh ../categorizer.py ../tools.py
+
+3.  Summarize pylint results saved in tmp.pylint
+        sh pylint.sh --summarize
+
+A summary of pylint results looks like this, 
+with a quality metric in col 2,
+and an observations-count in col 3.
+     1	10.00/10  3     __init__.py
+     2	7.27/10   13    __main__.py
+     3	8.23/10   166   analyzebehavior.py
+     4	8.68/10   217   analyzebehavior_dt.py
+     5	7.30/10   255   categorizer.py
+     6	7.29/10   17    central_logging.py
+     7	8.93/10   15    config.py
+     8	7.36/10   30    detector.py
+     9	8.59/10   156   gui_analyzer.py
+    10	8.59/10   172   gui_categorizer.py
+    11	7.98/10   82    gui_detector.py
+    12	6.77/10   67    gui_main.py
+    13	8.60/10   78    gui_preprocessor.py
+    14	7.56/10   31    minedata.py
+    15	9.50/10   7     myargparse.py
+    16	8.35/10   21    mylogging.py
+    17	7.50/10   5     mypkg_resources.py
+    18	8.12/10   13    probes.py
+    19	8.52/10   16    registration.py
+    20	8.57/10   112   tools.py

--- a/LabGym/tests/pylint.sh
+++ b/LabGym/tests/pylint.sh
@@ -1,0 +1,706 @@
+source INIT.sh
+
+if [ $# -gt 0 ]; then
+    PYFILES=$*
+fi
+printf "%s: %s\n" "\$PYFILES" "$PYFILES"
+
+IS_VENV || { ERROR "Expected a venv..."; exit 1; }
+
+OUTDIR=$PWD/tmp.pylint
+RCFILE=$(basename "$PWD")/pylintrc
+
+setopt SH_WORD_SPLIT 2> /dev/null
+(cd .. && {
+    for F in $PYFILES; do
+        OPTS="--rcfile $RCFILE"
+
+        # C0301: Line too long (232/100) (line-too-long)
+        # W0311: Bad indentation. Found 2 spaces, expected 8 (bad-indentation)
+        OPTS="$OPTS${OPTS:+ }--disable=C0301,W0311"
+
+        (set -x; pylint $OPTS $F > "$OUTDIR"/pylint.$F.out)
+        grep -n "^Your code has been rated " "$OUTDIR"/pylint.$F.out
+    done
+})
+
+exit $?
+========================================================================
+To summarize pylint results saved to tmp.pylint,
+    (cd tmp.pylint && grep -n "Your code has been rated at" *.out) | 
+    sed "s/ (previous.*//" | 
+    sed "s/^pylint\.\(.*.py\).out:\([0-9]*\):Your code has been rated at \(.*\)/\3\t\2\t\1/" | 
+    expand -10,16 |
+    cat -n
+========================================================================
+usage: pylint [options]
+
+options:
+  -h, --help            show this help message and exit
+
+Commands:
+  Options which are actually commands. Options in this group are mutually exclusive.
+
+  --rcfile RCFILE       Specify a configuration file to load.
+  --output OUTPUT       Specify an output file.
+  --help-msg HELP_MSG [HELP_MSG ...]
+                        Display a help message for the given message id and
+                        exit. The value may be a comma separated list of
+                        message ids.
+  --list-msgs           Display a list of all pylint's messages divided by
+                        whether they are emittable with the given interpreter.
+  --list-msgs-enabled   Display a list of what messages are enabled, disabled
+                        and non-emittable with the given configuration.
+  --list-groups         List pylint's message groups.
+  --list-conf-levels    Generate pylint's confidence levels.
+  --list-extensions     List available extensions.
+  --full-documentation  Generate pylint's full documentation.
+  --generate-rcfile     Generate a sample configuration file according to the
+                        current configuration. You can put other options
+                        before this one to get them in the generated
+                        configuration.
+  --generate-toml-config
+                        Generate a sample configuration file according to the
+                        current configuration. You can put other options
+                        before this one to get them in the generated
+                        configuration. The config is in the .toml format.
+  --long-help           Show more verbose help.
+
+Main:
+  --init-hook INIT_HOOK
+                        Python code to execute, usually for sys.path
+                        manipulation such as pygtk.require().
+  --errors-only, -E     In error mode, messages with a category besides ERROR
+                        or FATAL are suppressed, and no reports are done by
+                        default. Error mode is compatible with disabling
+                        specific errors.
+  --verbose , -v        In verbose mode, extra non-checker-related info will
+                        be displayed.
+  --enable-all-extensions 
+                        Load and enable all available extensions. Use --list-
+                        extensions to see a list all available extensions.
+  --ignore <file>[,<file>...]
+                        Files or directories to be skipped. They should be
+                        base names, not paths. (default: ('CVS',))
+  --ignore-patterns <pattern>[,<pattern>...]
+                        Files or directories matching the regular expression
+                        patterns are skipped. The regex matches against base
+                        names, not paths. The default value ignores Emacs file
+                        locks (default: (re.compile('^\\.#'),))
+  --ignore-paths <pattern>[,<pattern>...]
+                        Add files or directories matching the regular
+                        expressions patterns to the ignore-list. The regex
+                        matches against paths and can be in Posix or Windows
+                        format. Because '\\' represents the directory
+                        delimiter on Windows systems, it can't be used as an
+                        escape character. (default: [])
+  --persistent <y or n>
+                        Pickle collected data for later comparisons. (default:
+                        True)
+  --load-plugins <modules>
+                        List of plugins (as comma separated values of python
+                        module names) to load, usually to register additional
+                        checkers. (default: ())
+  --fail-under <score>  Specify a score threshold under which the program will
+                        exit with error. (default: 10)
+  --fail-on <msg ids>   Return non-zero exit code if any of these
+                        messages/categories are detected, even if score is
+                        above --fail-under value. Syntax same as enable.
+                        Messages specified are enabled, while categories only
+                        check already-enabled messages. (default: )
+  --jobs <n-processes>, -j <n-processes>
+                        Use multiple processes to speed up Pylint. Specifying
+                        0 will auto-detect the number of processors available
+                        to use, and will cap the count on Windows to avoid
+                        hangs. (default: 1)
+  --limit-inference-results <number-of-results>
+                        Control the amount of potential inferred values when
+                        inferring a single object. This can help the
+                        performance when dealing with large functions or
+                        complex, nested conditions. (default: 100)
+  --extension-pkg-allow-list <pkg[,pkg]>
+                        A comma-separated list of package or module names from
+                        where C extensions may be loaded. Extensions are
+                        loading into the active Python interpreter and may run
+                        arbitrary code. (default: [])
+  --extension-pkg-whitelist <pkg[,pkg]>
+                        A comma-separated list of package or module names from
+                        where C extensions may be loaded. Extensions are
+                        loading into the active Python interpreter and may run
+                        arbitrary code. (This is an alternative name to
+                        extension-pkg-allow-list for backward compatibility.)
+                        (default: [])
+  --suggestion-mode <y or n>
+                        When enabled, pylint would attempt to guess common
+                        misconfiguration and emit user-friendly hints instead
+                        of false-positive error messages. (default: True)
+  --exit-zero           Always return a 0 (non-error) status code, even if
+                        lint errors are found. This is primarily useful in
+                        continuous integration scripts. (default: False)
+  --from-stdin          Interpret the stdin as a python script, whose filename
+                        needs to be passed as the module_or_package argument.
+                        (default: False)
+  --source-roots <path>[,<path>...]
+                        Add paths to the list of the source roots. Supports
+                        globbing patterns. The source root is an absolute path
+                        or a path relative to the current working directory
+                        used to determine a package namespace for modules
+                        located under the source root. (default: ())
+  --recursive <yn>      Discover python modules and packages in the file
+                        system subtree. (default: False)
+  --py-version <py_version>
+                        Minimum Python version to use for version dependent
+                        checks. Will default to the version used to run
+                        pylint. (default: (3, 10))
+  --ignored-modules <module names>
+                        List of module names for which member attributes
+                        should not be checked and will not be imported (useful
+                        for modules/projects where namespaces are manipulated
+                        during runtime and thus existing member attributes
+                        cannot be deduced by static analysis). It supports
+                        qualified module names, as well as Unix pattern
+                        matching. (default: ())
+  --analyse-fallback-blocks <y or n>
+                        Analyse import fallback blocks. This can be used to
+                        support both Python 2 and 3 compatible code, which
+                        means that the block might have code that exists only
+                        in one or another interpreter, leading to false
+                        positives when analysed. (default: False)
+  --clear-cache-post-run <y or n>
+                        Clear in-memory caches upon conclusion of linting.
+                        Useful if running pylint in a server-like mode.
+                        (default: False)
+  --prefer-stubs <y or n>
+                        Resolve imports to .pyi stubs if available. May reduce
+                        no-member messages and increase not-an-iterable
+                        messages. (default: False)
+
+Reports:
+  Options related to output formatting and reporting
+
+  --output-format <format>, -f <format>
+                        Set the output format. Available formats are: 'text',
+                        'parseable', 'colorized', 'json2' (improved json
+                        format), 'json' (old json format), msvs (visual
+                        studio) and 'github' (GitHub actions). You can also
+                        give a reporter class, e.g.
+                        mypackage.mymodule.MyReporterClass.
+  --reports <y or n>, -r <y or n>
+                        Tells whether to display a full report or only the
+                        messages. (default: False)
+  --evaluation <python_expression>
+                        Python expression which should return a score less
+                        than or equal to 10. You have access to the variables
+                        'fatal', 'error', 'warning', 'refactor', 'convention',
+                        and 'info' which contain the number of messages in
+                        each category, as well as 'statement' which is the
+                        total number of statements analyzed. This score is
+                        used by the global evaluation report (RP0004).
+                        (default: max(0, 0 if fatal else 10.0 - ((float(5 *
+                        error + warning + refactor + convention) / statement)
+                        * 10)))
+  --score <y or n>, -s <y or n>
+                        Activate the evaluation score. (default: True)
+  --msg-template <template>
+                        Template used to display messages. This is a python
+                        new-style format string used to format the message
+                        information. See doc for all details. (default: )
+
+Messages control:
+  Options controlling analysis messages
+
+  --confidence <levels>
+                        Only show warnings with the listed confidence levels.
+                        Leave empty to show all. Valid levels: HIGH,
+                        CONTROL_FLOW, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
+                        (default: ['HIGH', 'CONTROL_FLOW', 'INFERENCE',
+                        'INFERENCE_FAILURE', 'UNDEFINED'])
+  --enable <msg ids>, -e <msg ids>
+                        Enable the message, report, category or checker with
+                        the given id(s). You can either give multiple
+                        identifier separated by comma (,) or put this option
+                        multiple time (only on the command line, not in the
+                        configuration file where it should appear only once).
+                        See also the "--disable" option for examples.
+  --disable <msg ids>, -d <msg ids>
+                        Disable the message, report, category or checker with
+                        the given id(s). You can either give multiple
+                        identifiers separated by comma (,) or put this option
+                        multiple times (only on the command line, not in the
+                        configuration file where it should appear only once).
+                        You can also use "--disable=all" to disable everything
+                        first and then re-enable specific checks. For example,
+                        if you want to run only the similarities checker, you
+                        can use "--disable=all --enable=similarities". If you
+                        want to run only the classes checker, but have no
+                        Warning level messages displayed, use "--disable=all
+                        --enable=classes --disable=W".
+
+Logging:
+  Checks use of the logging module.
+
+  --logging-modules <comma separated list>
+                        Logging modules to check that the string format
+                        arguments are in logging function parameter format.
+                        (default: ('logging',))
+  --logging-format-style <old (%) or new ({)>
+                        The type of string formatting that logging methods do.
+                        `old` means using % formatting, `new` is for `{}`
+                        formatting. (default: old)
+
+Spelling:
+  Check spelling in comments and docstrings.
+
+  --spelling-dict <dict name>
+                        Spelling dictionary name. No available dictionaries :
+                        You need to install both the python package and the
+                        system dependency for enchant to work. (default: )
+  --spelling-ignore-words <comma separated words>
+                        List of comma separated words that should not be
+                        checked. (default: )
+  --spelling-private-dict-file <path to file>
+                        A path to a file that contains the private dictionary;
+                        one word per line. (default: )
+  --spelling-store-unknown-words <y or n>
+                        Tells whether to store unknown words to the private
+                        dictionary (see the --spelling-private-dict-file
+                        option) instead of raising a message. (default: n)
+  --max-spelling-suggestions N
+                        Limits count of emitted suggestions for spelling
+                        mistakes. (default: 4)
+  --spelling-ignore-comment-directives <comma separated words>
+                        List of comma separated words that should be
+                        considered directives if they appear at the beginning
+                        of a comment and should not be checked. (default: fmt:
+                        on,fmt: off,noqa:,noqa,nosec,isort:skip,mypy:)
+
+Miscellaneous:
+  BaseChecker for encoding issues.
+
+  --notes <comma separated values>
+                        List of note tags to take in consideration, separated
+                        by a comma. (default: ('FIXME', 'XXX', 'TODO'))
+  --notes-rgx <regexp>  Regular expression of note tags to take in
+                        consideration. (default: )
+
+Similarities:
+  Checks for similarities and duplicated code.
+
+  --min-similarity-lines <int>
+                        Minimum lines number of a similarity. (default: 4)
+  --ignore-comments <y or n>
+                        Comments are removed from the similarity computation
+                        (default: True)
+  --ignore-docstrings <y or n>
+                        Docstrings are removed from the similarity computation
+                        (default: True)
+  --ignore-imports <y or n>
+                        Imports are removed from the similarity computation
+                        (default: True)
+  --ignore-signatures <y or n>
+                        Signatures are removed from the similarity computation
+                        (default: True)
+
+Typecheck:
+  Try to find bugs in the code using type inference.
+
+  --ignore-on-opaque-inference <y or n>
+                        This flag controls whether pylint should warn about
+                        no-member and similar checks whenever an opaque object
+                        is returned when inferring. The inference can return
+                        multiple potential results while evaluating a Python
+                        object, but some branches might not be evaluated,
+                        which results in partial inference. In that case, it
+                        might be useful to still emit no-member and other
+                        checks for the rest of the inferred objects. (default:
+                        True)
+  --mixin-class-rgx <regexp>
+                        Regex pattern to define which classes are considered
+                        mixins. (default: .*[Mm]ixin)
+  --ignore-mixin-members <y or n>
+                        Tells whether missing members accessed in mixin class
+                        should be ignored. A class is considered mixin if its
+                        name matches the mixin-class-rgx option. (default:
+                        True)
+  --ignored-checks-for-mixins <list of messages names>
+                        List of symbolic message names to ignore for Mixin
+                        members. (default: ['no-member', 'not-async-context-
+                        manager', 'not-context-manager', 'attribute-defined-
+                        outside-init'])
+  --ignore-none <y or n>
+                        Tells whether to warn about missing members when the
+                        owner of the attribute is inferred to be None.
+                        (default: True)
+  --ignored-classes <members names>
+                        List of class names for which member attributes should
+                        not be checked (useful for classes with dynamically
+                        set attributes). This supports the use of qualified
+                        names. (default: ('optparse.Values', 'thread._local',
+                        '_thread._local', 'argparse.Namespace'))
+  --generated-members <members names>
+                        List of members which are set dynamically and missed
+                        by pylint inference system, and so shouldn't trigger
+                        E1101 when accessed. Python regular expressions are
+                        accepted. (default: ())
+  --contextmanager-decorators <decorator names>
+                        List of decorators that produce context managers, such
+                        as contextlib.contextmanager. Add to this list to
+                        register other decorators that produce valid context
+                        managers. (default: ['contextlib.contextmanager'])
+  --missing-member-hint-distance <member hint edit distance>
+                        The maximum edit distance a name should have in order
+                        to be considered a similar match for a missing member
+                        name. (default: 1)
+  --missing-member-max-choices <member hint max choices>
+                        The total number of similar names that should be taken
+                        in consideration when showing a hint for a missing
+                        member. (default: 1)
+  --missing-member-hint <missing member hint>
+                        Show a hint with possible names when a member name was
+                        not found. The aspect of finding the hint is based on
+                        edit distance. (default: True)
+  --signature-mutators <decorator names>
+                        List of decorators that change the signature of a
+                        decorated function. (default: [])
+
+Classes:
+  Checker for class nodes.
+
+  --defining-attr-methods <method names>
+                        List of method names used to declare (i.e. assign)
+                        instance attributes. (default: ('__init__', '__new__',
+                        'setUp', 'asyncSetUp', '__post_init__'))
+  --valid-classmethod-first-arg <argument names>
+                        List of valid names for the first argument in a class
+                        method. (default: ('cls',))
+  --valid-metaclass-classmethod-first-arg <argument names>
+                        List of valid names for the first argument in a
+                        metaclass class method. (default: ('mcs',))
+  --exclude-protected <protected access exclusions>
+                        List of member names, which should be excluded from
+                        the protected access warning. (default: ('_asdict',
+                        '_fields', '_replace', '_source', '_make',
+                        'os._exit'))
+  --check-protected-access-in-special-methods <y or n>
+                        Warn about protected attribute access inside special
+                        methods (default: False)
+
+Variables:
+  BaseChecker for variables.
+
+  --init-import <y or n>
+                        Tells whether we should check for unused import in
+                        __init__ files. (default: False)
+  --dummy-variables-rgx <regexp>
+                        A regular expression matching the name of dummy
+                        variables (i.e. expected to not be used). (default: _+
+                        $|(_[a-zA-Z0-9_]*[a-zA-Z0-
+                        9]+?$)|dummy|^ignored_|^unused_)
+  --additional-builtins <comma separated list>
+                        List of additional names supposed to be defined in
+                        builtins. Remember that you should avoid defining new
+                        builtins when possible. (default: ())
+  --callbacks <callbacks>
+                        List of strings which can identify a callback function
+                        by name. A callback name must start or end with one of
+                        those strings. (default: ('cb_', '_cb'))
+  --redefining-builtins-modules <comma separated list>
+                        List of qualified module names which can have objects
+                        that can redefine builtins. (default: ('six.moves',
+                        'past.builtins', 'future.builtins', 'builtins', 'io'))
+  --ignored-argument-names <regexp>
+                        Argument names that match this expression will be
+                        ignored. (default:
+                        re.compile('_.*|^ignored_|^unused_'))
+  --allow-global-unused-variables <y or n>
+                        Tells whether unused global variables should be
+                        treated as a violation. (default: True)
+  --allowed-redefined-builtins <comma separated list>
+                        List of names allowed to shadow builtins (default: ())
+
+Format:
+  Formatting checker.
+
+  --max-line-length <int>
+                        Maximum number of characters on a single line.
+                        (default: 100)
+  --ignore-long-lines <regexp>
+                        Regexp for a line that is allowed to be longer than
+                        the limit. (default: ^\s*(# )?<?https?://\S+>?$)
+  --single-line-if-stmt <y or n>
+                        Allow the body of an if to be on the same line as the
+                        test if there is no else. (default: False)
+  --single-line-class-stmt <y or n>
+                        Allow the body of a class to be on the same line as
+                        the declaration if body contains single statement.
+                        (default: False)
+  --max-module-lines <int>
+                        Maximum number of lines in a module. (default: 1000)
+  --indent-string <string>
+                        String used as indentation unit. This is usually " "
+                        (4 spaces) or "\t" (1 tab). (default: )
+  --indent-after-paren <int>
+                        Number of spaces of indent required inside a hanging
+                        or continued line. (default: 4)
+  --expected-line-ending-format <empty or LF or CRLF>
+                        Expected format of line ending, e.g. empty (any line
+                        ending), LF or CRLF. (default: )
+
+Imports:
+  BaseChecker for import statements.
+
+  --deprecated-modules <modules>
+                        Deprecated modules which should not be used, separated
+                        by a comma. (default: ())
+  --preferred-modules <module:preferred-module>
+                        Couples of modules and preferred modules, separated by
+                        a comma. (default: ())
+  --import-graph <file.gv>
+                        Output a graph (.gv or any supported image format) of
+                        all (i.e. internal and external) dependencies to the
+                        given file (report RP0402 must not be disabled).
+                        (default: )
+  --ext-import-graph <file.gv>
+                        Output a graph (.gv or any supported image format) of
+                        external dependencies to the given file (report RP0402
+                        must not be disabled). (default: )
+  --int-import-graph <file.gv>
+                        Output a graph (.gv or any supported image format) of
+                        internal dependencies to the given file (report RP0402
+                        must not be disabled). (default: )
+  --known-standard-library <modules>
+                        Force import order to recognize a module as part of
+                        the standard compatibility libraries. (default: ())
+  --known-third-party <modules>
+                        Force import order to recognize a module as part of a
+                        third party library. (default: ('enchant',))
+  --allow-any-import-level <modules>
+                        List of modules that can be imported at any level, not
+                        just the top level one. (default: ())
+  --allow-wildcard-with-all <y or n>
+                        Allow wildcard imports from modules that define
+                        __all__. (default: False)
+  --allow-reexport-from-package <y or n>
+                        Allow explicit reexports by alias from a package
+                        __init__. (default: False)
+
+Method_args:
+  BaseChecker for method_args.
+
+  --timeout-methods <comma separated list>
+                        List of qualified names (i.e., library.method) which
+                        require a timeout parameter e.g.
+                        'requests.api.get,requests.api.post' (default:
+                        ('requests.api.delete', 'requests.api.get',
+                        'requests.api.head', 'requests.api.options',
+                        'requests.api.patch', 'requests.api.post',
+                        'requests.api.put', 'requests.api.request'))
+
+Exceptions:
+  Exception related checks.
+
+  --overgeneral-exceptions <comma-separated class names>
+                        Exceptions that will emit a warning when caught.
+                        (default: ('builtins.BaseException',
+                        'builtins.Exception'))
+
+Refactoring:
+  Looks for code which can be refactored.
+
+  --max-nested-blocks <int>
+                        Maximum number of nested blocks for function / method
+                        body (default: 5)
+  --never-returning-functions <members names>
+                        Complete name of functions that never returns. When
+                        checking for inconsistent-return-statements if a never
+                        returning function is called then it will be
+                        considered as an explicit return statement and no
+                        message will be printed. (default: ('sys.exit',
+                        'argparse.parse_error'))
+  --suggest-join-with-non-empty-separator <y or n>
+                        Let 'consider-using-join' be raised when the separator
+                        to join on would be non-empty (resulting in expected
+                        fixes of the type: ``"- " + " - ".join(items)``)
+                        (default: True)
+
+Design:
+  Checker of potential misdesigns.
+
+  --max-args <int>      Maximum number of arguments for function / method.
+                        (default: 5)
+  --max-positional-arguments <int>
+                        Maximum number of positional arguments for function /
+                        method. (default: 5)
+  --max-locals <int>    Maximum number of locals for function / method body.
+                        (default: 15)
+  --max-returns <int>   Maximum number of return / yield for function / method
+                        body. (default: 6)
+  --max-branches <int>  Maximum number of branch for function / method body.
+                        (default: 12)
+  --max-statements <int>
+                        Maximum number of statements in function / method
+                        body. (default: 50)
+  --max-parents <num>   Maximum number of parents for a class (see R0901).
+                        (default: 7)
+  --ignored-parents <comma separated list of class names>
+                        List of qualified class names to ignore when counting
+                        class parents (see R0901) (default: ())
+  --max-attributes <num>
+                        Maximum number of attributes for a class (see R0902).
+                        (default: 7)
+  --min-public-methods <num>
+                        Minimum number of public methods for a class (see
+                        R0903). (default: 2)
+  --max-public-methods <num>
+                        Maximum number of public methods for a class (see
+                        R0904). (default: 20)
+  --max-bool-expr <num>
+                        Maximum number of boolean expressions in an if
+                        statement (see R0916). (default: 5)
+  --exclude-too-few-public-methods <pattern>[,<pattern>...]
+                        List of regular expressions of class ancestor names to
+                        ignore when counting public methods (see R0903)
+                        (default: [])
+
+String:
+  Check string literals.
+
+  --check-str-concat-over-line-jumps <y or n>
+                        This flag controls whether the implicit-str-concat
+                        should generate a warning on implicit string
+                        concatenation in sequences defined over several lines.
+                        (default: False)
+  --check-quote-consistency <y or n>
+                        This flag controls whether inconsistent-quotes
+                        generates a warning when the character used as a quote
+                        delimiter is used inconsistently within a module.
+                        (default: False)
+
+Basic:
+  --good-names <names>  Good variable names which should always be accepted,
+                        separated by a comma. (default: ('i', 'j', 'k', 'ex',
+                        'Run', '_'))
+  --good-names-rgxs <names>
+                        Good variable names regexes, separated by a comma. If
+                        names match any regex, they will always be accepted
+                        (default: )
+  --bad-names <names>   Bad variable names which should always be refused,
+                        separated by a comma. (default: ('foo', 'bar', 'baz',
+                        'toto', 'tutu', 'tata'))
+  --bad-names-rgxs <names>
+                        Bad variable names regexes, separated by a comma. If
+                        names match any regex, they will always be refused
+                        (default: )
+  --name-group <name1:name2>
+                        Colon-delimited sets of names that determine each
+                        other's naming style when the name regexes allow
+                        several styles. (default: ())
+  --include-naming-hint <y or n>
+                        Include a hint for the correct naming format with
+                        invalid-name. (default: False)
+  --property-classes <decorator names>
+                        List of decorators that produce properties, such as
+                        abc.abstractproperty. Add to this list to register
+                        other decorators that produce valid properties. These
+                        decorators are taken in consideration only for
+                        invalid-name. (default: ('abc.abstractproperty',))
+  --argument-naming-style <style>
+                        Naming style matching correct argument names.
+                        (default: snake_case)
+  --argument-rgx <regexp>
+                        Regular expression matching correct argument names.
+                        Overrides argument-naming-style. If left empty,
+                        argument names will be checked with the set naming
+                        style. (default: None)
+  --attr-naming-style <style>
+                        Naming style matching correct attribute names.
+                        (default: snake_case)
+  --attr-rgx <regexp>   Regular expression matching correct attribute names.
+                        Overrides attr-naming-style. If left empty, attribute
+                        names will be checked with the set naming style.
+                        (default: None)
+  --class-naming-style <style>
+                        Naming style matching correct class names. (default:
+                        PascalCase)
+  --class-rgx <regexp>  Regular expression matching correct class names.
+                        Overrides class-naming-style. If left empty, class
+                        names will be checked with the set naming style.
+                        (default: None)
+  --class-attribute-naming-style <style>
+                        Naming style matching correct class attribute names.
+                        (default: any)
+  --class-attribute-rgx <regexp>
+                        Regular expression matching correct class attribute
+                        names. Overrides class-attribute-naming-style. If left
+                        empty, class attribute names will be checked with the
+                        set naming style. (default: None)
+  --class-const-naming-style <style>
+                        Naming style matching correct class constant names.
+                        (default: UPPER_CASE)
+  --class-const-rgx <regexp>
+                        Regular expression matching correct class constant
+                        names. Overrides class-const-naming-style. If left
+                        empty, class constant names will be checked with the
+                        set naming style. (default: None)
+  --const-naming-style <style>
+                        Naming style matching correct constant names.
+                        (default: UPPER_CASE)
+  --const-rgx <regexp>  Regular expression matching correct constant names.
+                        Overrides const-naming-style. If left empty, constant
+                        names will be checked with the set naming style.
+                        (default: None)
+  --function-naming-style <style>
+                        Naming style matching correct function names.
+                        (default: snake_case)
+  --function-rgx <regexp>
+                        Regular expression matching correct function names.
+                        Overrides function-naming-style. If left empty,
+                        function names will be checked with the set naming
+                        style. (default: None)
+  --inlinevar-naming-style <style>
+                        Naming style matching correct inline iteration names.
+                        (default: any)
+  --inlinevar-rgx <regexp>
+                        Regular expression matching correct inline iteration
+                        names. Overrides inlinevar-naming-style. If left
+                        empty, inline iteration names will be checked with the
+                        set naming style. (default: None)
+  --method-naming-style <style>
+                        Naming style matching correct method names. (default:
+                        snake_case)
+  --method-rgx <regexp>
+                        Regular expression matching correct method names.
+                        Overrides method-naming-style. If left empty, method
+                        names will be checked with the set naming style.
+                        (default: None)
+  --module-naming-style <style>
+                        Naming style matching correct module names. (default:
+                        snake_case)
+  --module-rgx <regexp>
+                        Regular expression matching correct module names.
+                        Overrides module-naming-style. If left empty, module
+                        names will be checked with the set naming style.
+                        (default: None)
+  --typealias-rgx <regexp>
+                        Regular expression matching correct type alias names.
+                        If left empty, type alias names will be checked with
+                        the set naming style. (default: None)
+  --typevar-rgx <regexp>
+                        Regular expression matching correct type variable
+                        names. If left empty, type variable names will be
+                        checked with the set naming style. (default: None)
+  --variable-naming-style <style>
+                        Naming style matching correct variable names.
+                        (default: snake_case)
+  --variable-rgx <regexp>
+                        Regular expression matching correct variable names.
+                        Overrides variable-naming-style. If left empty,
+                        variable names will be checked with the set naming
+                        style. (default: None)
+  --no-docstring-rgx <regexp>
+                        Regular expression which should only match function or
+                        class names that do not require a docstring. (default:
+                        re.compile('^_'))
+  --docstring-min-length <int>
+                        Minimum line length for functions/classes that require
+                        docstrings, shorter ones are exempt. (default: -1)

--- a/LabGym/tests/pylint.sh
+++ b/LabGym/tests/pylint.sh
@@ -1,28 +1,31 @@
 source INIT.sh
 
+PYFILES=$(echo ../*.py)
+
 if [ $# -gt 0 ]; then
     PYFILES=$*
 fi
-printf "%s: %s\n" "\$PYFILES" "$PYFILES"
+
+DEBUG "%s: %s" "\$PYFILES" "$PYFILES"
 
 IS_VENV || { ERROR "Expected a venv..."; exit 1; }
 
-OUTDIR=$PWD/tmp.pylint
-RCFILE=$(basename "$PWD")/pylintrc
+OUTDIR=tmp.pylint
 
 setopt SH_WORD_SPLIT 2> /dev/null
-(cd .. && {
+(
     for F in $PYFILES; do
-        OPTS="--rcfile $RCFILE"
+        OUTFILE=$OUTDIR/pylint.$(echo $F | tr / . | sed "s/^\.\.\.//").out
+        OPTS="--rcfile pylintrc"
 
         # C0301: Line too long (232/100) (line-too-long)
         # W0311: Bad indentation. Found 2 spaces, expected 8 (bad-indentation)
         OPTS="$OPTS${OPTS:+ }--disable=C0301,W0311"
 
-        (set -x; pylint $OPTS $F > "$OUTDIR"/pylint.$F.out)
-        grep -n "^Your code has been rated " "$OUTDIR"/pylint.$F.out
+        (set -x; pylint $OPTS $F > $OUTFILE)
+        grep -n "^Your code has been rated " $OUTFILE
     done
-})
+)
 
 exit $?
 ========================================================================

--- a/LabGym/tests/pylint.sh
+++ b/LabGym/tests/pylint.sh
@@ -2,6 +2,19 @@ source INIT.sh
 
 PYFILES=$(echo ../*.py)
 
+OP=pylint  # default OP
+while [ $# -gt 0 ]; do
+    case $1 in
+        --summarize)  OP=summarize; shift;;
+        --)  shift; break;;
+        -*)  ERROR "Bad usage.  Unsupported option ($1)"; exit 1;;
+        *)  break;;
+    esac
+done
+
+case $OP in
+pylint)
+#-----------------------------------------------------------------------
 if [ $# -gt 0 ]; then
     PYFILES=$*
 fi
@@ -26,15 +39,21 @@ setopt SH_WORD_SPLIT 2> /dev/null
         grep -n "^Your code has been rated " $OUTFILE
     done
 )
+#-----------------------------------------------------------------------
+;;
+
+summarize)
+#-----------------------------------------------------------------------
+(cd tmp.pylint && grep -n "Your code has been rated at" *.out) | 
+sed "s/ (previous.*//" | 
+sed "s/^pylint\.\(.*.py\).out:\([0-9]*\):Your code has been rated at \(.*\)/\3\t\2\t\1/" | 
+expand -10,16 |
+cat -n
+#-----------------------------------------------------------------------
+;;
+esac
 
 exit $?
-========================================================================
-To summarize pylint results saved to tmp.pylint,
-    (cd tmp.pylint && grep -n "Your code has been rated at" *.out) | 
-    sed "s/ (previous.*//" | 
-    sed "s/^pylint\.\(.*.py\).out:\([0-9]*\):Your code has been rated at \(.*\)/\3\t\2\t\1/" | 
-    expand -10,16 |
-    cat -n
 ========================================================================
 usage: pylint [options]
 

--- a/LabGym/tests/pylintrc
+++ b/LabGym/tests/pylintrc
@@ -1,0 +1,647 @@
+[MAIN]
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Clear in-memory caches upon conclusion of linting. Useful if running pylint
+# in a server-like mode.
+clear-cache-post-run=no
+
+# Load and enable all available extensions. Use --list-extensions to see a list
+# all available extensions.
+#enable-all-extensions=
+
+# In error mode, messages with a category besides ERROR or FATAL are
+# suppressed, and no reports are done by default. Error mode is compatible with
+# disabling specific errors.
+#errors-only=
+
+# Always return a 0 (non-error) status code, even if lint errors are found.
+# This is primarily useful in continuous integration scripts.
+#exit-zero=
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-allow-list=
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code. (This is an alternative name to extension-pkg-allow-list
+# for backward compatibility.)
+extension-pkg-whitelist=
+
+# Return non-zero exit code if any of these messages/categories are detected,
+# even if score is above --fail-under value. Syntax same as enable. Messages
+# specified are enabled, while categories only check already-enabled messages.
+fail-on=
+
+# Specify a score threshold under which the program will exit with error.
+fail-under=10
+
+# Interpret the stdin as a python script, whose filename needs to be passed as
+# the module_or_package argument.
+#from-stdin=
+
+# Files or directories to be skipped. They should be base names, not paths.
+ignore=CVS
+
+# Add files or directories matching the regular expressions patterns to the
+# ignore-list. The regex matches against paths and can be in Posix or Windows
+# format. Because '\\' represents the directory delimiter on Windows systems,
+# it can't be used as an escape character.
+ignore-paths=
+
+# Files or directories matching the regular expression patterns are skipped.
+# The regex matches against base names, not paths. The default value ignores
+# Emacs file locks
+ignore-patterns=^\.#
+
+# List of module names for which member attributes should not be checked and
+# will not be imported (useful for modules/projects where namespaces are
+# manipulated during runtime and thus existing member attributes cannot be
+# deduced by static analysis). It supports qualified module names, as well as
+# Unix pattern matching.
+ignored-modules=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use, and will cap the count on Windows to
+# avoid hangs.
+jobs=1
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python module names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Resolve imports to .pyi stubs if available. May reduce no-member messages and
+# increase not-an-iterable messages.
+prefer-stubs=no
+
+# Minimum Python version to use for version dependent checks. Will default to
+# the version used to run pylint.
+py-version=3.10
+
+# Discover python modules and packages in the file system subtree.
+recursive=no
+
+# Add paths to the list of the source roots. Supports globbing patterns. The
+# source root is an absolute path or a path relative to the current working
+# directory used to determine a package namespace for modules located under the
+# source root.
+source-roots=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+# In verbose mode, extra non-checker-related info will be displayed.
+#verbose=
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style. If left empty, argument names will be checked with the set
+# naming style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style. If left empty, attribute names will be checked with the set naming
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Bad variable names regexes, separated by a comma. If names match any regex,
+# they will always be refused
+bad-names-rgxs=
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style. If left empty, class attribute names will be checked
+# with the set naming style.
+#class-attribute-rgx=
+
+# Naming style matching correct class constant names.
+class-const-naming-style=UPPER_CASE
+
+# Regular expression matching correct class constant names. Overrides class-
+# const-naming-style. If left empty, class constant names will be checked with
+# the set naming style.
+#class-const-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style. If left empty, class names will be checked with the set naming style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style. If left empty, constant names will be checked with the set naming
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style. If left empty, function names will be checked with the set
+# naming style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Good variable names regexes, separated by a comma. If names match any regex,
+# they will always be accepted
+good-names-rgxs=
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style. If left empty, inline iteration names will be checked
+# with the set naming style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style. If left empty, method names will be checked with the set naming style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style. If left empty, module names will be checked with the set naming style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Regular expression matching correct type alias names. If left empty, type
+# alias names will be checked with the set naming style.
+#typealias-rgx=
+
+# Regular expression matching correct type variable names. If left empty, type
+# variable names will be checked with the set naming style.
+#typevar-rgx=
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style. If left empty, variable names will be checked with the set
+# naming style.
+#variable-rgx=
+
+
+[CLASSES]
+
+# Warn about protected attribute access inside special methods
+check-protected-access-in-special-methods=no
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp,
+                      asyncSetUp,
+                      __post_init__
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,_fields,_replace,_source,_make,os._exit
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[DESIGN]
+
+# List of regular expressions of class ancestor names to ignore when counting
+# public methods (see R0903)
+exclude-too-few-public-methods=
+
+# List of qualified class names to ignore when counting class parents (see
+# R0901)
+ignored-parents=
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement (see R0916).
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of positional arguments for function / method.
+max-positional-arguments=5
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when caught.
+overgeneral-exceptions=builtins.BaseException,builtins.Exception
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[IMPORTS]
+
+# List of modules that can be imported at any level, not just the top level
+# one.
+allow-any-import-level=
+
+# Allow explicit reexports by alias from a package __init__.
+allow-reexport-from-package=no
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=
+
+# Output a graph (.gv or any supported image format) of external dependencies
+# to the given file (report RP0402 must not be disabled).
+ext-import-graph=
+
+# Output a graph (.gv or any supported image format) of all (i.e. internal and
+# external) dependencies to the given file (report RP0402 must not be
+# disabled).
+import-graph=
+
+# Output a graph (.gv or any supported image format) of internal dependencies
+# to the given file (report RP0402 must not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+# Couples of modules and preferred modules, separated by a comma.
+preferred-modules=
+
+
+[LOGGING]
+
+# The type of string formatting that logging methods do. `old` means using %
+# formatting, `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, CONTROL_FLOW, INFERENCE, INFERENCE_FAILURE,
+# UNDEFINED.
+confidence=HIGH,
+           CONTROL_FLOW,
+           INFERENCE,
+           INFERENCE_FAILURE,
+           UNDEFINED
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then re-enable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        use-symbolic-message-instead,
+        use-implicit-booleaness-not-comparison-to-string,
+        use-implicit-booleaness-not-comparison-to-zero
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=
+
+
+[METHOD_ARGS]
+
+# List of qualified names (i.e., library.method) which require a timeout
+# parameter e.g. 'requests.api.get,requests.api.post'
+timeout-methods=requests.api.delete,requests.api.get,requests.api.head,requests.api.options,requests.api.patch,requests.api.post,requests.api.put,requests.api.request
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+# Regular expression of note tags to take in consideration.
+notes-rgx=
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit,argparse.parse_error
+
+# Let 'consider-using-join' be raised when the separator to join on would be
+# non-empty (resulting in expected fixes of the type: ``"- " + " -
+# ".join(items)``)
+suggest-join-with-non-empty-separator=yes
+
+
+[REPORTS]
+
+# Python expression which should return a score less than or equal to 10. You
+# have access to the variables 'fatal', 'error', 'warning', 'refactor',
+# 'convention', and 'info' which contain the number of messages in each
+# category, as well as 'statement' which is the total number of statements
+# analyzed. This score is used by the global evaluation report (RP0004).
+evaluation=max(0, 0 if fatal else 10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10))
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+msg-template=
+
+# Set the output format. Available formats are: 'text', 'parseable',
+# 'colorized', 'json2' (improved json format), 'json' (old json format), msvs
+# (visual studio) and 'github' (GitHub actions). You can also give a reporter
+# class, e.g. mypackage.mymodule.MyReporterClass.
+#output-format=
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[SIMILARITIES]
+
+# Comments are removed from the similarity computation
+ignore-comments=yes
+
+# Docstrings are removed from the similarity computation
+ignore-docstrings=yes
+
+# Imports are removed from the similarity computation
+ignore-imports=yes
+
+# Signatures are removed from the similarity computation
+ignore-signatures=yes
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. No available dictionaries : You need to install
+# both the python package and the system dependency for enchant to work.
+spelling-dict=
+
+# List of comma separated words that should be considered directives if they
+# appear at the beginning of a comment and should not be checked.
+spelling-ignore-comment-directives=fmt: on,fmt: off,noqa:,noqa,nosec,isort:skip,mypy:
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains the private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to the private dictionary (see the
+# --spelling-private-dict-file option) instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[STRING]
+
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=no
+
+# This flag controls whether the implicit-str-concat should generate a warning
+# on implicit string concatenation in sequences defined over several lines.
+check-str-concat-over-line-jumps=no
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=cv2,wx
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of symbolic message names to ignore for Mixin members.
+ignored-checks-for-mixins=no-member,
+                          not-async-context-manager,
+                          not-context-manager,
+                          attribute-defined-outside-init
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local,argparse.Namespace
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The maximum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+# Regex pattern to define which classes are considered mixins.
+mixin-class-rgx=.*[Mm]ixin
+
+# List of decorators that change the signature of a decorated function.
+signature-mutators=
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of names allowed to shadow builtins
+allowed-redefined-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io

--- a/LabGym/tests/pylintrc-
+++ b/LabGym/tests/pylintrc-
@@ -1,0 +1,647 @@
+[MAIN]
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Clear in-memory caches upon conclusion of linting. Useful if running pylint
+# in a server-like mode.
+clear-cache-post-run=no
+
+# Load and enable all available extensions. Use --list-extensions to see a list
+# all available extensions.
+#enable-all-extensions=
+
+# In error mode, messages with a category besides ERROR or FATAL are
+# suppressed, and no reports are done by default. Error mode is compatible with
+# disabling specific errors.
+#errors-only=
+
+# Always return a 0 (non-error) status code, even if lint errors are found.
+# This is primarily useful in continuous integration scripts.
+#exit-zero=
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-allow-list=
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code. (This is an alternative name to extension-pkg-allow-list
+# for backward compatibility.)
+extension-pkg-whitelist=
+
+# Return non-zero exit code if any of these messages/categories are detected,
+# even if score is above --fail-under value. Syntax same as enable. Messages
+# specified are enabled, while categories only check already-enabled messages.
+fail-on=
+
+# Specify a score threshold under which the program will exit with error.
+fail-under=10
+
+# Interpret the stdin as a python script, whose filename needs to be passed as
+# the module_or_package argument.
+#from-stdin=
+
+# Files or directories to be skipped. They should be base names, not paths.
+ignore=CVS
+
+# Add files or directories matching the regular expressions patterns to the
+# ignore-list. The regex matches against paths and can be in Posix or Windows
+# format. Because '\\' represents the directory delimiter on Windows systems,
+# it can't be used as an escape character.
+ignore-paths=
+
+# Files or directories matching the regular expression patterns are skipped.
+# The regex matches against base names, not paths. The default value ignores
+# Emacs file locks
+ignore-patterns=^\.#
+
+# List of module names for which member attributes should not be checked and
+# will not be imported (useful for modules/projects where namespaces are
+# manipulated during runtime and thus existing member attributes cannot be
+# deduced by static analysis). It supports qualified module names, as well as
+# Unix pattern matching.
+ignored-modules=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use, and will cap the count on Windows to
+# avoid hangs.
+jobs=1
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python module names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Resolve imports to .pyi stubs if available. May reduce no-member messages and
+# increase not-an-iterable messages.
+prefer-stubs=no
+
+# Minimum Python version to use for version dependent checks. Will default to
+# the version used to run pylint.
+py-version=3.10
+
+# Discover python modules and packages in the file system subtree.
+recursive=no
+
+# Add paths to the list of the source roots. Supports globbing patterns. The
+# source root is an absolute path or a path relative to the current working
+# directory used to determine a package namespace for modules located under the
+# source root.
+source-roots=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+# In verbose mode, extra non-checker-related info will be displayed.
+#verbose=
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style. If left empty, argument names will be checked with the set
+# naming style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style. If left empty, attribute names will be checked with the set naming
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Bad variable names regexes, separated by a comma. If names match any regex,
+# they will always be refused
+bad-names-rgxs=
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style. If left empty, class attribute names will be checked
+# with the set naming style.
+#class-attribute-rgx=
+
+# Naming style matching correct class constant names.
+class-const-naming-style=UPPER_CASE
+
+# Regular expression matching correct class constant names. Overrides class-
+# const-naming-style. If left empty, class constant names will be checked with
+# the set naming style.
+#class-const-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style. If left empty, class names will be checked with the set naming style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style. If left empty, constant names will be checked with the set naming
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style. If left empty, function names will be checked with the set
+# naming style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Good variable names regexes, separated by a comma. If names match any regex,
+# they will always be accepted
+good-names-rgxs=
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style. If left empty, inline iteration names will be checked
+# with the set naming style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style. If left empty, method names will be checked with the set naming style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style. If left empty, module names will be checked with the set naming style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Regular expression matching correct type alias names. If left empty, type
+# alias names will be checked with the set naming style.
+#typealias-rgx=
+
+# Regular expression matching correct type variable names. If left empty, type
+# variable names will be checked with the set naming style.
+#typevar-rgx=
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style. If left empty, variable names will be checked with the set
+# naming style.
+#variable-rgx=
+
+
+[CLASSES]
+
+# Warn about protected attribute access inside special methods
+check-protected-access-in-special-methods=no
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp,
+                      asyncSetUp,
+                      __post_init__
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,_fields,_replace,_source,_make,os._exit
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[DESIGN]
+
+# List of regular expressions of class ancestor names to ignore when counting
+# public methods (see R0903)
+exclude-too-few-public-methods=
+
+# List of qualified class names to ignore when counting class parents (see
+# R0901)
+ignored-parents=
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement (see R0916).
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of positional arguments for function / method.
+max-positional-arguments=5
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when caught.
+overgeneral-exceptions=builtins.BaseException,builtins.Exception
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[IMPORTS]
+
+# List of modules that can be imported at any level, not just the top level
+# one.
+allow-any-import-level=
+
+# Allow explicit reexports by alias from a package __init__.
+allow-reexport-from-package=no
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=
+
+# Output a graph (.gv or any supported image format) of external dependencies
+# to the given file (report RP0402 must not be disabled).
+ext-import-graph=
+
+# Output a graph (.gv or any supported image format) of all (i.e. internal and
+# external) dependencies to the given file (report RP0402 must not be
+# disabled).
+import-graph=
+
+# Output a graph (.gv or any supported image format) of internal dependencies
+# to the given file (report RP0402 must not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+# Couples of modules and preferred modules, separated by a comma.
+preferred-modules=
+
+
+[LOGGING]
+
+# The type of string formatting that logging methods do. `old` means using %
+# formatting, `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, CONTROL_FLOW, INFERENCE, INFERENCE_FAILURE,
+# UNDEFINED.
+confidence=HIGH,
+           CONTROL_FLOW,
+           INFERENCE,
+           INFERENCE_FAILURE,
+           UNDEFINED
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then re-enable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        use-symbolic-message-instead,
+        use-implicit-booleaness-not-comparison-to-string,
+        use-implicit-booleaness-not-comparison-to-zero
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=
+
+
+[METHOD_ARGS]
+
+# List of qualified names (i.e., library.method) which require a timeout
+# parameter e.g. 'requests.api.get,requests.api.post'
+timeout-methods=requests.api.delete,requests.api.get,requests.api.head,requests.api.options,requests.api.patch,requests.api.post,requests.api.put,requests.api.request
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+# Regular expression of note tags to take in consideration.
+notes-rgx=
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit,argparse.parse_error
+
+# Let 'consider-using-join' be raised when the separator to join on would be
+# non-empty (resulting in expected fixes of the type: ``"- " + " -
+# ".join(items)``)
+suggest-join-with-non-empty-separator=yes
+
+
+[REPORTS]
+
+# Python expression which should return a score less than or equal to 10. You
+# have access to the variables 'fatal', 'error', 'warning', 'refactor',
+# 'convention', and 'info' which contain the number of messages in each
+# category, as well as 'statement' which is the total number of statements
+# analyzed. This score is used by the global evaluation report (RP0004).
+evaluation=max(0, 0 if fatal else 10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10))
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+msg-template=
+
+# Set the output format. Available formats are: 'text', 'parseable',
+# 'colorized', 'json2' (improved json format), 'json' (old json format), msvs
+# (visual studio) and 'github' (GitHub actions). You can also give a reporter
+# class, e.g. mypackage.mymodule.MyReporterClass.
+#output-format=
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[SIMILARITIES]
+
+# Comments are removed from the similarity computation
+ignore-comments=yes
+
+# Docstrings are removed from the similarity computation
+ignore-docstrings=yes
+
+# Imports are removed from the similarity computation
+ignore-imports=yes
+
+# Signatures are removed from the similarity computation
+ignore-signatures=yes
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. No available dictionaries : You need to install
+# both the python package and the system dependency for enchant to work.
+spelling-dict=
+
+# List of comma separated words that should be considered directives if they
+# appear at the beginning of a comment and should not be checked.
+spelling-ignore-comment-directives=fmt: on,fmt: off,noqa:,noqa,nosec,isort:skip,mypy:
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains the private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to the private dictionary (see the
+# --spelling-private-dict-file option) instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[STRING]
+
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=no
+
+# This flag controls whether the implicit-str-concat should generate a warning
+# on implicit string concatenation in sequences defined over several lines.
+check-str-concat-over-line-jumps=no
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of symbolic message names to ignore for Mixin members.
+ignored-checks-for-mixins=no-member,
+                          not-async-context-manager,
+                          not-context-manager,
+                          attribute-defined-outside-init
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local,argparse.Namespace
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The maximum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+# Regex pattern to define which classes are considered mixins.
+mixin-class-rgx=.*[Mm]ixin
+
+# List of decorators that change the signature of a decorated function.
+signature-mutators=
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of names allowed to shadow builtins
+allowed-redefined-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io

--- a/LabGym/tools.py
+++ b/LabGym/tools.py
@@ -16,34 +16,41 @@ USA
 Email: bingye@umich.edu
 '''
 
+# Standard library imports.
+from collections import deque
+import datetime
+import functools
+import gc
+import logging
+import math
+import operator
+import os
+import shutil
+
 # Log the load of this module (by the module loader, on first import).
 # Intentionally positioning these statements before other imports, against the
 # guidance of PEP-8, to log the load before other imports log messages.
-import logging
-logger =  logging.getLogger(__name__)
-logger.debug('loading %s', __file__)
+logger =  logging.getLogger(__name__)  # pylint: disable=wrong-import-position
+logger.debug('loading %s', __file__)  # pylint: disable=wrong-import-position
 
-
-import os
-import gc
+# Related third party imports.
 import cv2
+from matplotlib.colorbar import ColorbarBase
+from matplotlib.colors import LinearSegmentedColormap,Normalize
+import matplotlib.pyplot as plt
 import numpy as np
-import datetime
+import pandas as pd
+from PIL import Image,ImageEnhance
+import seaborn as sb
 from skimage import exposure
 logger.debug('importing tensorflow.keras.preprocessing.image (starting...)')
-from tensorflow.keras.preprocessing.image import img_to_array
+from tensorflow import keras  # pylint: disable=unused-import
+# from tensorflow.keras.preprocessing.image import img_to_array
+from keras.preprocessing.image import img_to_array
 logger.debug('importing tensorflow.keras.preprocessing.image (done)')
-from collections import deque
-import matplotlib.pyplot as plt
-from matplotlib.colors import LinearSegmentedColormap,Normalize
-from matplotlib.colorbar import ColorbarBase
-from PIL import Image,ImageEnhance
-import pandas as pd
-import seaborn as sb
-import functools
-import operator
-import math
-import shutil
+
+# Local application/library specific imports.
+# (none)
 
 
 def extract_background(frames,stable_illumination=True,animal_vs_bg=0):

--- a/LabGym/tools.py
+++ b/LabGym/tools.py
@@ -1415,5 +1415,3 @@ def sort_examples_from_csv(path_to_examples,out_path):
 						shutil.move(path_to_pattern_image,os.path.join(out_path,str(behavior_name),os.path.splitext(basename)[0]+'.jpg'))
 
 	print('Sorting completed!')
-
-

--- a/LabGym/tools.py
+++ b/LabGym/tools.py
@@ -2,7 +2,7 @@
 Copyright (C)
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-You should have received a copy of the GNU General Public License along with this program. If not, see https://tldrlegal.com/license/gnu-general-public-license-v3-(gpl-3)#fulltext. 
+You should have received a copy of the GNU General Public License along with this program. If not, see https://tldrlegal.com/license/gnu-general-public-license-v3-(gpl-3)#fulltext.
 
 For license issues, please contact:
 
@@ -49,7 +49,7 @@ import shutil
 def extract_background(frames,stable_illumination=True,animal_vs_bg=0):
 
 	'''
-	This function is used in 'background subtraction based detection method', 
+	This function is used in 'background subtraction based detection method',
 	which extract the static background of a video.
 
 	animal_vs_bg: 0--animals brighter than the background
@@ -58,7 +58,7 @@ def extract_background(frames,stable_illumination=True,animal_vs_bg=0):
 	'''
 
 	len_frames=len(frames)
-	
+
 	if len_frames<=3:
 
 		background=None
@@ -79,7 +79,7 @@ def extract_background(frames,stable_illumination=True,animal_vs_bg=0):
 				while n<len_frames-101:
 					frames_temp=frames[n:n+100]
 					mean=frames_temp.mean(0)
-					frames_mean.append(mean)	
+					frames_mean.append(mean)
 					check_frames.append(abs(mean-mean_overall)+frames_temp.std(0))
 					n+=30
 
@@ -94,7 +94,7 @@ def extract_background(frames,stable_illumination=True,animal_vs_bg=0):
 
 			else:
 
-				background=np.uint8(np.median(frames,axis=0))	
+				background=np.uint8(np.median(frames,axis=0))
 
 		else:
 
@@ -139,7 +139,7 @@ def extract_background(frames,stable_illumination=True,animal_vs_bg=0):
 						background=np.uint8(frames.max(0))
 					else:
 						background=np.uint8(frames.min(0))
-	
+
 	return background
 
 
@@ -147,7 +147,7 @@ def estimate_constants(path_to_video,delta,animal_number,framewidth=None,framehe
 
 	'''
 	This function is in 'background subtraction based detection method',
-	which determines the time windows for background extraction and 
+	which determines the time windows for background extraction and
 	estimating animal size, as well as finding the stimulation start time.
 
 	delta: a float number that detemines fold changes of illumination when it's considered as stimulation start time point
@@ -334,7 +334,7 @@ def estimate_constants(path_to_video,delta,animal_number,framewidth=None,framehe
 	print(datetime.datetime.now())
 
 	if delta<10000:
-		
+
 		if ex_start!=0 or path_background is not None:
 
 			capture=cv2.VideoCapture(path_to_video)
@@ -359,7 +359,7 @@ def estimate_constants(path_to_video,delta,animal_number,framewidth=None,framehe
 					if np.mean(frame)>delta*np.mean(frame_initial):
 						stim_t=frame_count/fps
 						break
-						
+
 				frame_count+=1
 
 			capture.release()
@@ -506,7 +506,7 @@ def extract_blob_background(frame,contours,contour=None,channel=1,background_fre
 
 	'''
 	This function is used to keep the pixels for the area
-	inside a contour, and crop the frame to fit a list of 
+	inside a contour, and crop the frame to fit a list of
 	contours. It can also include background pixels.
 
 	channel: 1--gray scale blob
@@ -537,7 +537,7 @@ def extract_blob_all(frame,y_bt,y_tp,x_lf,x_rt,contours=None,channel=1,backgroun
 
 	'''
 	This function is used to keep the pixels for the area
-	inside a list of contours, and crop the frame to fit 
+	inside a list of contours, and crop the frame to fit
 	the y_bt,y_tp,x_lf,x_rt coordinates.
 
 	channel: 1--gray scale blob
@@ -619,7 +619,7 @@ def contour_frame(frame,animal_number,background,background_low,background_high,
 			foreground=cv2.absdiff(frame_dt,background)
 		else:
 			foreground=cv2.subtract(frame_dt,background)
-			
+
 	foreground=cv2.cvtColor(foreground,cv2.COLOR_BGR2GRAY)
 	thred=cv2.threshold(foreground,0,255,cv2.THRESH_BINARY+cv2.THRESH_OTSU)[1]
 	thred=cv2.morphologyEx(thred,cv2.MORPH_CLOSE,np.ones((kernel,kernel),np.uint8))
@@ -662,7 +662,7 @@ def contour_frame(frame,animal_number,background,background_low,background_high,
 def generate_patternimage(frame,outlines,inners=None,std=0):
 
 	'''
-	This function is used to generate pattern images 
+	This function is used to generate pattern images
 	in 'non-interactive' behavior mode.
 
 	inners: the inner contours when body parts are inlcuded in the pattern images
@@ -684,7 +684,7 @@ def generate_patternimage(frame,outlines,inners=None,std=0):
 	for n,outline in enumerate(outlines):
 
 		if outline is not None:
-				
+
 			if inners is not None:
 				background_std=np.zeros_like(frame)
 				cv2.drawContours(background_std,inners[n],-1,(255,255,255),-1)
@@ -694,7 +694,7 @@ def generate_patternimage(frame,outlines,inners=None,std=0):
 				d=n*int((255*4/length))
 				cv2.drawContours(background_outlines,[outline],0,(255,d,0),p_size)
 				if inners is not None:
-					cv2.drawContours(background_inners,inners[n],-1,(255,d,0),p_size)	
+					cv2.drawContours(background_inners,inners[n],-1,(255,d,0),p_size)
 			elif n<length/2:
 				d=int((n-length/4)*(255*4/length))
 				cv2.drawContours(background_outlines,[outline],0,(255,255,d),p_size)
@@ -734,7 +734,7 @@ def generate_patternimage(frame,outlines,inners=None,std=0):
 def generate_patternimage_all(frame,y_bt,y_tp,x_lf,x_rt,outlines_list,inners_list,std=0):
 
 	'''
-	This function is used to generate pattern images 
+	This function is used to generate pattern images
 	in 'interactive basic' behavior mode.
 
 	y_bt...x_rt: the coordinates that determine the border of the pattern images
@@ -772,7 +772,7 @@ def generate_patternimage_all(frame,y_bt,y_tp,x_lf,x_rt,outlines_list,inners_lis
 			cv2.drawContours(background_outlines,outlines,-1,(255,d,0),p_size)
 			if inners_length>0:
 				for inners in inners_list[n]:
-					cv2.drawContours(background_inners,inners,-1,(255,d,0),p_size)	
+					cv2.drawContours(background_inners,inners,-1,(255,d,0),p_size)
 		elif n<length/2:
 			d=int((n-length/4)*(255*4/length))
 			cv2.drawContours(background_outlines,outlines,-1,(255,255,d),p_size)
@@ -817,7 +817,7 @@ def generate_patternimage_all(frame,y_bt,y_tp,x_lf,x_rt,outlines_list,inners_lis
 def generate_patternimage_interact(frame,outlines,other_outlines,inners=None,other_inners=None,std=0):
 
 	'''
-	This function is used to generate pattern images 
+	This function is used to generate pattern images
 	in 'interactive advanced' behavior mode.
 
 	other_outlines: the contours of animals / objects that are not the 'main character'
@@ -911,7 +911,7 @@ def plot_events(result_path,event_probability,time_points,names_and_colors,behav
 	'''
 	This function is used to plot a raster plot for behavior events and probability
 	over time based on the 'event_probability' and 'time_points'.
-	
+
 	names_and_colors: the behavior names and their representative colors
 	width and height: the size of the plot, when ==0, the size is defined automatically
 	'''
@@ -936,7 +936,7 @@ def plot_events(result_path,event_probability,time_points,names_and_colors,behav
 		figure,ax=plt.subplots(figsize=(width,height))
 		if height<=5:
 			figure.subplots_adjust(bottom=0.25)
-	
+
 	for behavior_name in behavior_to_include:
 
 		all_data=[]
@@ -960,19 +960,19 @@ def plot_events(result_path,event_probability,time_points,names_and_colors,behav
 		dataframe=pd.DataFrame(all_data,columns=[float('{:.1f}'.format(i)) for i in time_points])
 
 		heatmap=sb.heatmap(dataframe,mask=masks,xticklabels=x_intvl,cmap=LinearSegmentedColormap.from_list('',names_and_colors[behavior_name]),cbar=False,vmin=0,vmax=1)
-		heatmap.set_xticklabels(heatmap.get_xticklabels(),rotation=90) 
+		heatmap.set_xticklabels(heatmap.get_xticklabels(),rotation=90)
 		# if don't want the ticks
 		# ax.tick_params(axis='both',which='both',length=0)
-	
+
 	plt.savefig(os.path.join(result_path,'behaviors_plot.png'))
 
-	for behavior_name in behavior_to_include: 
+	for behavior_name in behavior_to_include:
 
 		colorbar_fig=plt.figure(figsize=(5,1))
 		ax=colorbar_fig.add_axes([0,1,1,1])
 		colorbar=ColorbarBase(ax,orientation='horizontal',cmap=LinearSegmentedColormap.from_list('',names_and_colors[behavior_name]),norm=Normalize(vmin=0,vmax=1),ticks=[])
 		colorbar.outline.set_linewidth(0)
-			
+
 		plt.savefig(os.path.join(result_path,behavior_name+'_colorbar.png'),bbox_inches='tight')
 		plt.close()
 
@@ -985,7 +985,7 @@ def extract_frames(path_to_video,out_path,framewidth=None,start_t=0,duration=0,s
 
 	'''
 	This function is used to extract frames from a video.
-	
+
 	skip_redundant: the interval between two consecutively extracted frames
 	'''
 
@@ -1001,7 +1001,7 @@ def extract_frames(path_to_video,out_path,framewidth=None,start_t=0,duration=0,s
 	if duration<=0:
 		duration=full_duration
 	end_t=start_t+duration
-		
+
 	frame_count=1
 	frame_count_generate=0
 
@@ -1017,7 +1017,7 @@ def extract_frames(path_to_video,out_path,framewidth=None,start_t=0,duration=0,s
 			break
 
 		if t>=start_t:
-			
+
 			if frame_count_generate%skip_redundant==0:
 
 				if framewidth is not None:
@@ -1055,7 +1055,7 @@ def preprocess_video(
 
 	'''
 	This function is used to preprocess a video.
-	
+
 	time_windows: if trim_video is True, the time_windows will form a new, trimmed video
 	contrast: only valide if enhance_contrast is True
 	left...bottom: the edges defining the cropped frame if crop_frame is True
@@ -1159,17 +1159,17 @@ def preprocess_video(
 def parse_all_events_file(path_to_events):
 
 	'''
-	This function is used to parse an all_events.xlsx file and convert it into 
+	This function is used to parse an all_events.xlsx file and convert it into
 	a dict 'event_probability', a list 'time_points', and a list 'behavior_names'.
 
 	path_to_events: The path to the 'all_events.xlsx' file
 
-	event_probability is a dictionary with the keys as the ID of each animal / object 
-	and the values are lists of lists, where each sub-list has a length of 2 and is 
+	event_probability is a dictionary with the keys as the ID of each animal / object
+	and the values are lists of lists, where each sub-list has a length of 2 and is
 	in one of the following formats:
 
 		- ['NA', -1]
-		- [behavior, probability], where behavior is the name of the behavior 
+		- [behavior, probability], where behavior is the name of the behavior
 		and probability is a float between 0 and 1.
 
 	time_points is a list of floats containing the time points of the analysis duration.
@@ -1207,16 +1207,16 @@ def parse_all_events_file(path_to_events):
 def calculate_distances(path_to_folder,filename,behavior_to_include,out_path):
 
 	'''
-	This function is used to calculate the shortes distance and the total 
-	traveling dsitance and their ratio among the locations of the animals 
+	This function is used to calculate the shortes distance and the total
+	traveling dsitance and their ratio among the locations of the animals
 	when a selected behavior occurs for the first time.
 
 	For example, an animal explores locations A, B, and C in sequence.
-	This function will calculate the shortes distance that connects 
+	This function will calculate the shortes distance that connects
 	locations A, B, and C, in the exploration sequence of the aninmal.
-	It will also calculate the traveling distance of the actual route of 
+	It will also calculate the traveling distance of the actual route of
 	the animal.
-	
+
 	path_to_folder: The path to the folder that stores the 'all_event_probability.xlsx',
 	'all_centers.xlsx', and 'Annotated video.avi'.
 	filename: the name of the path_to_folder
@@ -1374,11 +1374,11 @@ def sort_examples_from_csv(path_to_examples,out_path):
 	'''
 	This function is used to sort behavior examples generated by LabGym according to
 	the manual labeling from other sources. It inputs the unsorted behavior examples
-	generated by LabGym and a .csv file that stores the frame-wise behavior labels, 
+	generated by LabGym and a .csv file that stores the frame-wise behavior labels,
 	and sort the unsorted examples into different behavior categories (labels) that
 	can be used to train a Categorizer in LabGym.
-	
-	path_to_examples: The folder that stores all unsorted examples generated by LabGym. 
+
+	path_to_examples: The folder that stores all unsorted examples generated by LabGym.
 	The .csv file should also be in this folder.
 	out_path: the folder to store the sorted behavior examples
 	'''


### PR DESCRIPTION
Provide a script "pylint.sh" and pylintrc to facilitate using pylint to analyze LabGym's pyfiles,
(The pylint defaults result in 2/3 of pyfiles being unmeasurable, reporting 0 out of 10).
Also, reorg import statements per PEP 8, especially to eliminate the 
"from tools import *" statements (!).  This to resolve many import warnings reported by pylint.

Why?
I like to use pylint to get an indication of quality for the code I submit for PR.
I have a self-imposed goal of PR-ing code with 8+/10 quality if it's my new module.
Or if I'm touching an existing module, I'd have a goal of not making its quality metric worse.

I'm happy to walk through the usage and output of pylint to ensure Henry/Bobby can use this tool as well.

```
        Before PR,      After PR, 
        metric &        metric & 
        alarm count     alarm count
     1  0.00/10  10     10.00/10 3      __init__.py
     2  0.30/10  36     9.39/10  6      __main__.py
     3  0.00/10  1357   8.93/10  108    analyzebehavior.py
     4  0.00/10  2463   9.00/10  170    analyzebehavior_dt.py
     5  0.00/10  1882   8.30/10  175    categorizer.py
     6  7.08/10  18     8.96/10  9      central_logging.py
     7  8.93/10  15     9.42/10  10     config.py
     8  0.00/10  154    7.52/10  28     detector.py
     9  0.00/10  1566   8.79/10  133    gui_analyzer.py
    10  0.00/10  1775   8.79/10  148    gui_categorizer.py
    11  0.00/10  520    8.49/10  62     gui_detector.py
    12  0.00/10  272    7.67/10  49     gui_main.py
    13  0.00/10  722    8.86/10  64     gui_preprocessor.py
    14  0.00/10  167    7.84/10  27     minedata.py
    15  9.17/10  9      9.50/10  7      myargparse.py
    16  8.35/10  21     8.54/10  19     mylogging.py
    17  0.00/10  25     7.50/10  5      mypkg_resources.py
    18  7.92/10  14     8.30/10  12     probes.py
    19  8.44/10  17     8.52/10  16     registration.py
    20  0.00/10  1239   9.09/10  69     tools.py
```