### PR TITLE
Revert to import from tensorflow instead of from keras.

### DIFF
--- a/LabGym/analyzebehavior.py
+++ b/LabGym/analyzebehavior.py
@@ -39,11 +39,11 @@ import pandas as pd
 from scipy.spatial import distance
 # import seaborn as sb
 import tensorflow as tf
-# from tensorflow.keras.models import load_model
-# from tensorflow.keras.preprocessing.image import img_to_array
-from tensorflow import keras  # pylint: disable=unused-import
-from keras.models import load_model
-from keras.preprocessing.image import img_to_array
+from tensorflow.keras.models import load_model
+from tensorflow.keras.preprocessing.image import img_to_array
+# from tensorflow import keras  # pylint: disable=unused-import
+# from keras.models import load_model
+# from keras.preprocessing.image import img_to_array
 
 # Local application/library specific imports.
 logger.debug('importing tools (starting...)')

--- a/LabGym/analyzebehavior_dt.py
+++ b/LabGym/analyzebehavior_dt.py
@@ -33,11 +33,11 @@ from scipy.spatial import distance
 # import seaborn as sb
 from skimage import exposure
 import tensorflow as tf
-# from tensorflow.keras.models import load_model
-# from tensorflow.keras.preprocessing.image import img_to_array
-from tensorflow import keras  # pylint: disable=unused-import
-from keras.models import load_model
-from keras.preprocessing.image import img_to_array
+from tensorflow.keras.models import load_model
+from tensorflow.keras.preprocessing.image import img_to_array
+# from tensorflow import keras  # pylint: disable=unused-import
+# from keras.models import load_model
+# from keras.preprocessing.image import img_to_array
 import torch
 
 # Local application/library specific imports.

--- a/LabGym/categorizer.py
+++ b/LabGym/categorizer.py
@@ -37,16 +37,8 @@ from sklearn.metrics import classification_report
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import LabelBinarizer
 import tensorflow as tf
-# from tensorflow.keras.callbacks import ModelCheckpoint,EarlyStopping,ReduceLROnPlateau
-# from tensorflow.keras.layers import Input,TimeDistributed,BatchNormalization,MaxPooling2D,Activation,ZeroPadding2D,Add
-# from tensorflow.keras.layers import Conv2D,Dropout,Flatten,Dense,LSTM,concatenate,AveragePooling2D,GlobalMaxPooling2D
-# from tensorflow.keras.models import Model,Sequential,load_model
-# from tensorflow.keras.optimizers import SGD
-# from tensorflow.keras.preprocessing.image import img_to_array,load_img
-# from tensorflow.keras.utils import plot_model,Sequence
-from tensorflow import keras  # pylint: disable=unused-import
-from keras.callbacks import ModelCheckpoint,EarlyStopping,ReduceLROnPlateau
-from keras.layers import (
+from tensorflow.keras.callbacks import ModelCheckpoint,EarlyStopping,ReduceLROnPlateau
+from tensorflow.keras.layers import (
     Activation,
     Add,
     AveragePooling2D,
@@ -63,20 +55,54 @@ from keras.layers import (
     ZeroPadding2D,
     concatenate,
     )
-from keras.models import (
+
+from tensorflow.keras.models import (
     Model,
     # Sequential,
     load_model,
     )
-from keras.optimizers import SGD
-from keras.preprocessing.image import (
+from tensorflow.keras.optimizers import SGD
+from tensorflow.keras.preprocessing.image import (
     img_to_array,
     # load_img,
     )
-from keras.utils import (
+from tensorflow.keras.utils import (
     # plot_model,
     Sequence,
     )
+# from tensorflow import keras  # pylint: disable=unused-import
+# from keras.callbacks import ModelCheckpoint,EarlyStopping,ReduceLROnPlateau
+# from keras.layers import (
+#     Activation,
+#     Add,
+#     AveragePooling2D,
+#     BatchNormalization,
+#     Conv2D,
+#     Dense,
+#     Dropout,
+#     Flatten,
+#     # GlobalMaxPooling2D,
+#     Input,
+#     LSTM,
+#     MaxPooling2D,
+#     TimeDistributed,
+#     ZeroPadding2D,
+#     concatenate,
+#     )
+# from keras.models import (
+#     Model,
+#     # Sequential,
+#     load_model,
+#     )
+# from keras.optimizers import SGD
+# from keras.preprocessing.image import (
+#     img_to_array,
+#     # load_img,
+#     )
+# from keras.utils import (
+#     # plot_model,
+#     Sequence,
+#     )
 
 # Local application/library specific imports.
 # (none)

--- a/LabGym/tools.py
+++ b/LabGym/tools.py
@@ -44,9 +44,9 @@ from PIL import Image,ImageEnhance
 import seaborn as sb
 from skimage import exposure
 logger.debug('importing tensorflow.keras.preprocessing.image (starting...)')
-from tensorflow import keras  # pylint: disable=unused-import
-# from tensorflow.keras.preprocessing.image import img_to_array
-from keras.preprocessing.image import img_to_array
+from tensorflow.keras.preprocessing.image import img_to_array
+# from tensorflow import keras  # pylint: disable=unused-import
+# from keras.preprocessing.image import img_to_array
 logger.debug('importing tensorflow.keras.preprocessing.image (done)')
 
 # Local application/library specific imports.


### PR DESCRIPTION
Reverting from keras imports to tensorflow imports, in an attempt to address Windows-only CI issue.  (Or more accurately, tensorflow 2.10.1 issue?).