### PR TITLE
Reimplement pkg_resources.resource_filename()

### DIFF
--- a/LabGym/mypkg_resources.py
+++ b/LabGym/mypkg_resources.py
@@ -1,76 +1,80 @@
-"""Import the deprecated pkg_resources package and suppress the warning.
-
-Subsequent imports will not reload pkg_resources and won't issue the warning.
-"""
-
-import warnings
-with warnings.catch_warnings():
-    warnings.simplefilter('ignore')  # Ignore all warnings
-    import pkg_resources
-
-
-# """Provide a replacement for the deprecated pkg_resources package.
+# """Import the deprecated pkg_resources package and suppress the warning.
 #
-# LabGym and detectron2 presently (2025-07-28) use the pkg_resources
-# package in a single module, detectron2/model_zoo/model_zoo.py.
-#      4  import pkg_resources
-#         ...
-#    139      cfg_file = pkg_resources.resource_filename(
-#    140          "detectron2.model_zoo", os.path.join("configs", config_path)
-#    141      )
-#
-# The pkg_resources package is deprecated.
-# When loaded, the pkg_resources package produces a user-facing warning.
-#
-# However, if this module is loaded before the genuine pkg_resources is loaded,
-# then
-# 1.  the warning message is caught/suppressed,
-# 2.  references to pkg_resources are mapped to this module, so
-#     pkg_resources.resource_filename refers to the function defined here.
-#
-# After this module is tested,
-# to show that the new_result follows the old_result,
-# the load of pkg_resources can be eliminated, and we can rely on the new_result.
+# Subsequent imports will not reload pkg_resources and won't issue the warning.
 # """
 #
-# import importlib.resources
-# import logging
-# import sys
 # import warnings
-#
-#
-# logger = logging.getLogger(__name__)
-# logger.debug('pkg_resources -- Loading...')
 # with warnings.catch_warnings():
 #     warnings.simplefilter('ignore')  # Ignore all warnings
-#     from pkg_resources import resource_filename as old_resource_filename
-# logger.debug('pkg_resources -- Loaded')
-#
-#
-# logger.debug('%s: %r',
-#     "sys.modules['pkg_resources']", sys.modules['pkg_resources'])
-# logger.debug('%s: %r',
-#     "sys.modules.get(__name__)", sys.modules.get(__name__))
-# sys.modules['pkg_resources'] = sys.modules.get(__name__)
-#
-#
-# def resource_filename(*args, **kwargs):
-#     logger.debug('old_resource_filename() -- Calling')
-#     logger.debug('%s: %r', 'args', args)
-#     logger.debug('%s: %r', 'kwargs', kwargs)
-#     old_result = old_resource_filename(*args, **kwargs)
-#     logger.debug('%s: %r', 'old_result', old_result)
-#
-#     # re-implement with importlib.resources.files()
-#     try:
-#         new_result = str(importlib.resources.files(args[0]) / args[1])
-#         logger.debug('%s: %r', 'new_result', new_result)
-#
-#         if new_result == old_result:
-#             logger.info(f'agreement {new_result}')
-#         else:
-#             logger.info(f'disagreement {new_result}, {old_result}')
-#     except:
-#         logger.warning(e)
-#
-#     return old_result
+#     import pkg_resources
+
+
+"""Provide a replacement for the deprecated pkg_resources package.
+
+LabGym and detectron2 presently (2025-07-28) use the pkg_resources
+package in a single module, detectron2/model_zoo/model_zoo.py.
+     4  import pkg_resources
+        ...
+   139      cfg_file = pkg_resources.resource_filename(
+   140          "detectron2.model_zoo", os.path.join("configs", config_path)
+   141      )
+
+The pkg_resources package is deprecated.
+When the pkg_resources package is loaded, it produces a user-facing warning.
+
+However, if this module is loaded before the genuine pkg_resources is
+loaded, then references to pkg_resources are mapped to this module, so
+(a) pkg_resources will not be loaded, and,
+(b) pkg_resources.resource_filename refers to the function defined in
+    this module.
+"""
+
+import importlib.resources
+import logging
+import sys
+
+
+# This module replaces the genuine pkg_resources package.
+sys.modules['pkg_resources'] = sys.modules.get(__name__)
+
+
+def resource_filename(*args):
+    """Emulate the pkg_resources.resource_filename function.
+ 
+    (from Google AI Overview)
+    pkg_resources.resource_filename() is a function from the
+    pkg_resources module (part of setuptools) in Python. It is used to
+    obtain the true filesystem path for a specified resource within a
+    Python package.
+
+    Purpose:
+    This function is particularly useful when you need to access files
+    within a package as actual files on the filesystem, rather than just
+    as strings or streams. This is often necessary for tasks like
+    loading configuration files, image assets, or other data files that
+    external libraries or tools might expect to find at a specific file
+    path.
+
+    How it works:
+    Package Resources: pkg_resources.resource_filename() takes two main
+    arguments:
+    *   package_or_requirement: The name of the package (e.g., 
+        'my_package') or a Requirement object.
+    *   resource_name: The path to the resource within that package 
+        (e.g., 'data/config.ini', 'images/icon.png').
+
+    Extraction (if needed): If the package is distributed in an archive
+    format (like a zipped .egg file), resource_filename() will extract
+    the requested resource (and potentially other related resources) to
+    a temporary cache directory and return the path to that extracted
+    file.
+
+    Direct Path (if available): If the package is installed directly
+    on the filesystem (e.g., as a directory), it will return the
+    direct path to the resource within that directory.
+    """
+
+    assert len(args) == 2
+
+    # re-implement with importlib.resources.files()
+    return str(importlib.resources.files(args[0]) / args[1])

--- a/LabGym/tests/coveragerc
+++ b/LabGym/tests/coveragerc
@@ -1,3 +1,25 @@
+# The .coveragerc file is a configuration file used by coverage.py, a
+# tool for measuring code coverage in Python projects. This file allows
+# users to customize various aspects of how coverage.py operates,
+# including which files to include or exclude from coverage reports, how
+# to handle specific lines of code, and the format of the output
+# reports.
+#
+# Key aspects of a .coveragerc file: 
+#   Purpose: It provides a centralized way to configure coverage.py
+#   settings, making it easier to maintain consistent coverage
+#   measurement across multiple test runs and environments.
+#   
+#   Location and Naming: The default name for the configuration file is
+#   .coveragerc, and it should be placed in the same directory where
+#   coverage.py is being run. Alternatively, a different file and
+#   location can be specified using the --rcfile command-line option or
+#   the COVERAGE_RCFILE environment variable.
+#   
+#   Content: The file uses an INI-style format with sections like [run],
+#   [report], [html], and [json], each containing specific options
+#   related to different stages of the coverage process.
+
 [run]
 omit =
     */detectron2/*

--- a/LabGym/tests/test_mypkg_resources.py
+++ b/LabGym/tests/test_mypkg_resources.py
@@ -60,10 +60,10 @@ def test_resource_filename():
     result = pkg_resources.resource_filename(*args)
 
     # Assert
-    assert result == os.path.join(
+    assert result == os.path.normpath(os.path.join(
         os.path.dirname(LabGym.detectron2.model_zoo.__file__),
         'configs/COCO-InstanceSegmentation/mask_rcnn_R_50_FPN_3x.yaml',
-        )
+        ))
 
 
 def test_pkg_resources_is_mypkg_resources():

--- a/LabGym/tests/test_mypkg_resources.py
+++ b/LabGym/tests/test_mypkg_resources.py
@@ -1,0 +1,118 @@
+import logging
+import os
+import pprint
+import sys
+
+import pytest  # pytest: simple powerful testing with Python
+
+from LabGym import mypkg_resources  # replace deprecated pkg_resources
+
+# this import should find that pkg_resources is already in sys.modules, so 
+# pkg_resources will not be loaded.
+import pkg_resources
+
+# By default, detectron2 imports cv2, and coverage analysis produces
+# warnings regarding two cv2 py-files
+#   .../site-packages/cv2/config.py
+#   .../site-packages/cv2/config-3.py
+# like
+#   Couldn't parse '.../LabGym/LabGym/tests/config-3.py':
+#   Couldn't parse '.../LabGym/LabGym/tests/config.py':
+# (because coverage is looking for the source in cwd instead of in 
+# site-packages/cv2?)
+#
+# One way to avoid those two coverage warnings to disable detectron2's 
+# import of cv2.
+os.environ['DETECTRON2_DISABLE_CV2'] = '1'  # use '1' for True here.
+
+import LabGym.detectron2.model_zoo
+from LabGym.detectron2 import model_zoo  # redundant, but convenient
+from LabGym.detectron2.config import get_cfg
+from LabGym.detectron2.modeling import build_model
+
+
+logger = logging.getLogger(__name__)
+logger.debug('%s:\n%s', 'sys.path', pprint.pformat(sys.path))
+
+
+def test_dummy():
+    # Arrange
+    # Act
+    pass
+    # Assert not necessary.  This unit test passes unless exception was raised.
+
+
+def test_resource_filename():
+    """Test that resource_filename emulates the genuine resource_filename."""
+
+    # Arrange
+    args = (
+        # package_or_requirement: The name of the package (e.g., 
+        # 'my_package') or a Requirement object.
+        'LabGym.detectron2.model_zoo',
+
+        # resource_name: The path to the resource within that package 
+        # (e.g., 'data/config.ini', 'images/icon.png')
+        'configs/COCO-InstanceSegmentation/mask_rcnn_R_50_FPN_3x.yaml',
+        )
+
+    # Act
+    result = pkg_resources.resource_filename(*args)
+
+    # Assert
+    assert result == os.path.join(
+        os.path.dirname(LabGym.detectron2.model_zoo.__file__),
+        'configs/COCO-InstanceSegmentation/mask_rcnn_R_50_FPN_3x.yaml',
+        )
+
+
+def test_pkg_resources_is_mypkg_resources():
+    """Test that pkg_resources has been replaced by mypkg_resources."""
+
+    assert sys.modules['pkg_resources'] == sys.modules['LabGym.mypkg_resources']
+
+
+# def test_get_returns_model():
+#     """Test that model_zoo.get() successfully returns a model."""
+def test_prepare_model_cfg():
+    """Test that a model cfg can be prepared from default and config file."""
+
+    # Choose a common model from the model zoo for testing
+    config_path = "COCO-InstanceSegmentation/mask_rcnn_R_50_FPN_3x.yaml"
+
+    # Get the default configuration for the chosen model
+    cfg = get_cfg()
+    full_config_path = model_zoo.get_config_file(config_path)
+    cfg.merge_from_file(full_config_path)
+
+    return
+
+    # Build the model using the configuration
+    model = build_model(cfg)
+
+    # Assert that the model object an instance of torch.nn.Module
+    assert model is not None
+    assert isinstance(model, type(build_model(get_cfg())))
+
+
+def test_get_config_file_returns_path():
+    """Test that model_zoo.get_config_file() returns a valid file path."""
+
+    config_path = "COCO-InstanceSegmentation/mask_rcnn_R_50_FPN_3x.yaml"
+    file_path = model_zoo.get_config_file(config_path)
+
+    # Assert that the returned path is a string and points to an existing file
+    assert isinstance(file_path, str)
+    assert os.path.exists(file_path)
+
+
+def test_get_checkpoint_url_returns_url():
+    """Test that model_zoo.get_checkpoint_url() returns a valid URL."""
+
+    config_path = "COCO-InstanceSegmentation/mask_rcnn_R_50_FPN_3x.yaml"
+    checkpoint_url = model_zoo.get_checkpoint_url(config_path)
+
+    # Assert that the returned value is likely a URL (starts with http/https)
+    assert isinstance(checkpoint_url, str)
+    assert (checkpoint_url.startswith("http://")
+        or checkpoint_url.startswith("https://"))


### PR DESCRIPTION
Before the 8/22 symposium, I suppressed the user-facing warning message which is due to loading of the deprecated pkg_resources package from detectron2.model_zoo.py.

Now I am PR-ing the better solution, namely re-implementing the resource_filename function in mypkg_resources, so that the deprecated pkg_resources package is no longer even loaded.

This change is benign, it produces no change to behavior.