### PR TITLE
refactor to avoid potential second call to wx.App()

### DIFF
--- a/LabGym/__main__.py
+++ b/LabGym/__main__.py
@@ -51,7 +51,7 @@ import requests  # Python HTTP for Humans.
 # Local application/library specific imports.
 # pylint: disable-next=unused-import
 from LabGym import mypkg_resources  # replace deprecated pkg_resources
-from LabGym import __version__, gui_main, probes
+from LabGym import __version__, gui_main, mywx, probes
 
 
 logger.debug('%s: %r', '(__name__, __package__)', (__name__, __package__))
@@ -82,6 +82,10 @@ def main() -> None:
 	except:
 
 		pass
+
+	# Create a single persistent, wx.App instance, as it may be
+        # needed for probe dialogs prior to calling gui_main.main_window.
+	mywx.App()
 
 	# Perform some pre-op sanity checks and probes of outside resources.
 	probes.probes()

--- a/LabGym/gui_main.py
+++ b/LabGym/gui_main.py
@@ -416,10 +416,9 @@ class MainFrame(wx.Frame):
 			event.Skip()
 
 
-
 def main_window():
 	"""Display the main window."""
-	app = wx.App()
+	app = wx.GetApp()  # reference to the currently running wx.App instance
 	app.SetAppName("LabGym") # Set app name to influence WM_CLASS
 	setup_application_icons()  # Set up all platform-specific icons
 	

--- a/LabGym/mywx.py
+++ b/LabGym/mywx.py
@@ -1,0 +1,59 @@
+"""Provide function to guard from multiple instantiations of wx.App
+
+Use
+    import mywx
+    app = mywx.App()
+or
+    import mywx
+    mywx.App()
+instead of
+    import wx
+    app = wx.App()
+to avoid creating two wx.App objects at once.  
+
+This implementation uses the common approach of using a module-level 
+variable to store the value after its initial creation.
+This pattern is often referred to as memoization or lazy initialization.
+
+A side benefit of this implementation is that a reference to object
+is preserved (as module variable _cached_app), so it doesn't get garbage
+collected when used like
+    import mywx
+    mywx.App()
+
+"wx.App is supposed to be used as a singleton.  It doesn't own the 
+frames that are created in its OnInit, but instead assumes that it is 
+supposed to manage and deliver events to all the windows that exist in 
+the application."
+
+"the OnInit is called during the construction of the App (after the
+toolkit has been initialized) not during the MainLoop call."
+"""
+
+import logging
+
+import wx
+
+
+logger = logging.getLogger(__name__)
+
+
+_cached_app = None
+
+
+def App():
+    """Return the wx.App object."""
+
+    global _cached_app
+ 
+    if _cached_app is not None:
+        return _cached_app
+
+    # Milestone -- This must be the first time running this function.
+    # Construct the app obj, cache it, and return it.
+
+    app = wx.App()
+    logger.debug('%s: %r', 'app', app)
+
+    _cached_app = app
+    return app

--- a/LabGym/registration.py
+++ b/LabGym/registration.py
@@ -304,9 +304,6 @@ def _get_reginfo_from_form() -> dict | None:
         interact with other application windows while it's open.
     """
 
-    # Create a wx.App instance.
-    app = wx.App()
-
     with RegFormDialog(None) as dlg:
         logger.debug('%s -- %s', 'Milestone ShowModal', 'calling...')
         dlg.bring_to_foreground()


### PR DESCRIPTION
As I was developing another gui dialog for a different feature,
I learned that calling wx.App() multiple times can be problematic and is strongly advised against.
Presently it's called once with creation of a registration dialog,
and once in gui_main.main_window.

Although the developers haven't seen problems with the existing implementation -- 
maybe because the wx.App obj used by the registration dialog is garbage collected before gui_main.main_window is run? --
it makes sense to follow wx convention, and avoid calling wx.App() twice.

This PR removes the calls in gui_main.main_window and registration.registration,
and replaces them with a single call in __main__.py to mywx.App().  In addition, the mywx.App function adds protection so that if *it* is inadvertently called multiple times, it avoids instantiating another wx.App object.