### PR TITLE
Pip Install Fix - Expanding package build to entire project dir

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ path='LabGym/__init__.py'
 
 [tool.pdm.build]
 includes = [
-    "LabGym/assets/icons/"
+    "LabGym/"
 ]
 
 [tool.pdm.dev-dependencies]


### PR DESCRIPTION
This change expands package build to include entire LabGym/ directory. A previous commit of mine had a typo that only included LabGym/assets/icons subdirectory in the package build - apologies